### PR TITLE
Audit: remove dead platforms, fix broken links and data errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open-Sourced Collection of Bug Bounty Platforms
 
-An ongoing community-powered collection of all known bug bounty platforms, vulnerability disclosure platforms, and crowdsourced security platforms currently active on the Internet.  
+An ongoing community-powered collection of all known bug bounty platforms, vulnerability disclosure platforms, and crowdsourced security platforms currently active on the Internet.
 
 Is there a platform or detail missing, or have you spotted something wrong? This site is open source. [Improve this page](https://github.com/disclose/bug-bounty-platforms/edit/main/README.md)!
 
@@ -18,39 +18,35 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | bugbounty.jp | [https://bugbounty.jp](https://bugbounty.jp) | Japan | | Private + Public | | | [https://bugbounty.jp/en/](https://bugbounty.jp/en/) |
 | bugbounty.sa | [https://bugbounty.sa](https://bugbounty.sa) | Saudi Arabia | [@BugBountySA](https://x.com/BugBountySA) | Private | Yes | [https://bugbounty.sa/leaderboard](https://bugbounty.sa/leaderboard) | |
 | Bugcrowd | [https://bugcrowd.com](https://bugcrowd.com) | USA | [@bugcrowd](https://x.com/bugcrowd) | Private + Public | Yes | [https://bugcrowd.com/leaderboard](https://bugcrowd.com/leaderboard) | [https://bugcrowd.com/programs](https://bugcrowd.com/programs) |
-| BUGLOUD | [https://bugloud.com](https://bugloud.com) | United Arab Emirates | | Private + Public | | | |
 | BugRap | [https://bugrap.io](https://bugrap.io) | | [@BugRap_Team](https://x.com/BugRap_Team) | Public | Yes | [https://bugrap.io/whiteHats](https://bugrap.io/whiteHats) | [https://bugrap.io/bounties](https://bugrap.io/bounties) |
 | bugsbounty.io | [https://bugsbounty.io](https://bugsbounty.io) | England | [@bugsbounty_com](https://x.com/bugsbounty_com) | Private | | | |
-| Bugv | [https://bugv.io/](https://bugv.io/) | Nepal | [@bugvsecurity](https://x.com/bugvsecurity) | Public | Yes | | |
+| Bugv | [https://bugv.io](https://bugv.io) | Nepal | [@bugvsecurity](https://x.com/bugvsecurity) | Public | Yes | | |
 | Butian | [https://butian.net](https://butian.net) | China | | Private + Public | Yes | | |
 | Cantina | [https://cantina.xyz](https://cantina.xyz) | USA | [@Cantinaxyz](https://x.com/Cantinaxyz) | Private + Public | Yes | | [https://cantina.xyz/competitions](https://cantina.xyz/competitions) |
 | Capture The Bug | [https://capturethebug.xyz](https://capturethebug.xyz) | New Zealand | [@Capturethebugs](https://x.com/Capturethebugs) | Private | | | |
-| CertiK Bug Bounty | [https://certik.com](https://certik.com) | USA | [@CertiK](https://x.com/CertiK) | Private + Public | Yes | [https://skynet.certik.com/leaderboards/bug-bounty](https://skynet.certik.com/leaderboards/bug-bounty) | [https://skynet.certik.com/leaderboards/bug-bounty](https://skynet.certik.com/leaderboards/bug-bounty) |
-| CISA VDP Platform | [https://cisa.gov/vdp](https://cisa.gov/vdp) | USA | [@CISAgov](https://x.com/CISAgov) | Public | No | | |
+| CertiK Bug Bounty | [https://certik.com](https://certik.com) | USA | [@CertiK](https://x.com/CertiK) | Private + Public | Yes | [https://skynet.certik.com/leaderboards/bug-bounty](https://skynet.certik.com/leaderboards/bug-bounty) | |
+| CISA VDP Platform | [https://www.cisa.gov/vdp](https://www.cisa.gov/vdp) | USA | [@CISAgov](https://x.com/CISAgov) | Public | No | | |
 | Cobalt | [https://cobalt.io](https://cobalt.io) | USA | [@cobalt_io](https://x.com/cobalt_io) | Private | Yes | [https://app.cobalt.io/pentesters](https://app.cobalt.io/pentesters) | |
 | Code4rena | [https://code4rena.com](https://code4rena.com) | | [@code4rena](https://x.com/code4rena) | Public | Yes | [https://code4rena.com/leaderboard](https://code4rena.com/leaderboard) | [https://code4rena.com/contests](https://code4rena.com/contests) |
-| CodeHawks | [https://codehawks.cyfrin.io](https://codehawks.cyfrin.io) | USA | [@CodeHawks](https://x.com/CodeHawks) | Private + Public | Yes | [https://codehawks.cyfrin.io/leaderboard](https://codehawks.cyfrin.io/leaderboard) | [https://codehawks.cyfrin.io](https://codehawks.cyfrin.io) |
+| CodeHawks | [https://codehawks.cyfrin.io](https://codehawks.cyfrin.io) | USA | [@CodeHawks](https://x.com/CodeHawks) | Private + Public | Yes | [https://codehawks.cyfrin.io/leaderboard](https://codehawks.cyfrin.io/leaderboard) | |
 | Com Olho | [https://comolho.com](https://comolho.com) | India | [@com_olho](https://x.com/com_olho) | Private + Public | Yes | [https://cyber.comolho.com/researcher-community/](https://cyber.comolho.com/researcher-community/) | [https://cyber.comolho.com/programs/bug-bounty/](https://cyber.comolho.com/programs/bug-bounty/) |
 | Compass Security | [https://compass-security.com](https://compass-security.com) | Switzerland | [@compasssecurity](https://x.com/compasssecurity) | Private + Public | Yes | | [https://bugbounty.compass-security.com/](https://bugbounty.compass-security.com/) |
-| Crowdswarm | [https://crowdswarm.io](https://crowdswarm.io) | United Arab Emirates | [@Crowdswarm1](https://x.com/Crowdswarm1) | Private + Public | Yes | | [https://app.crowdswarm.io/p.html](https://app.crowdswarm.io/p.html) |
-| CyberTalents | [https://cybertalents.com](https://cybertalents.com) | Middle East | [@CyberTalents](https://x.com/CyberTalents) | Public | Yes | | |
+| Crowdswarm | [https://crowdswarm.io](https://crowdswarm.io) | United Arab Emirates | [@Crowdswarm1](https://x.com/Crowdswarm1) | Private + Public | Yes | | |
 | Cyber Army Indonesia | [https://cyberarmy.id](https://cyberarmy.id) | Indonesia | [@cyberarmyid](https://x.com/cyberarmyid) | Private + Public | Yes | [https://cyberarmy.id/leaderboard](https://cyberarmy.id/leaderboard) | [https://cyberarmy.id/programs](https://cyberarmy.id/programs) |
-| Cyber3ra | [https://cyber3ra.com](https://cyber3ra.com) | India | | Private + Public | Yes | | [https://app.cyber3ra.com](https://app.cyber3ra.com) |
+| CyberTalents | [https://cybertalents.com](https://cybertalents.com) | Middle East | [@CyberTalents](https://x.com/CyberTalents) | Public | Yes | | |
 | Cyscope | [https://cyscope.io](https://cyscope.io) | Switzerland & Latam | [@cy_scope](https://x.com/cy_scope) | Private + Public | Yes | | |
 | Detectify | [https://detectify.com](https://detectify.com) | Sweden | [@detectify](https://x.com/detectify) | Crowdsource (ASM) | Yes | | |
-| Dvuln | [https://dvuln.com](https://dvuln.com) | Australia | [@d_vuln](https://x.com/d_vuln) | Private | Yes | | [https://securityat.me/vdp_directory](https://securityat.me/vdp_directory) |
-| EpicBounties | [https://epicbounties.com](https://epicbounties.com) | Spain and LATAM | [@epicbounties](https://x.com/epicbounties) | Private + Public | Yes | [https://app.epicbounties.com/hunter-ranking](https://app.epicbounties.com/hunter-ranking) | [https://app.epicbounties.com/programs](https://app.epicbounties.com/programs) |
+| Dvuln | [https://dvuln.com](https://dvuln.com) | Australia | [@d_vuln](https://x.com/d_vuln) | Private | Yes | | |
 | Federacy | [https://federacy.com](https://federacy.com) | USA | [@_federacy](https://x.com/_federacy) | Private + Public | Yes | | |
 | Findbug | [https://findbug.io](https://findbug.io) | Kosovo | [@Findbugks](https://x.com/Findbugks) | Private | Yes | | |
 | Gerobug | [https://gerobug.gerosecurity.com](https://gerobug.gerosecurity.com) | Indonesia | | Self-hosted | No | | |
 | GObugfree | [https://gobugfree.com](https://gobugfree.com) | Switzerland | [@gobugfree](https://x.com/gobugfree) | Private + Public | Yes | | [https://app.gobugfree.com/programs](https://app.gobugfree.com/programs) |
-| Hacckers | [https://hacckers.com](https://hacckers.com) | Israel | | Private + Public | | | |
 | HackenProof | [https://hackenproof.com](https://hackenproof.com) | Estonia | [@HackenProof](https://x.com/HackenProof) | Private + Public | Yes | [https://hackenproof.com/leaderboard](https://hackenproof.com/leaderboard) | [https://hackenproof.com/programs](https://hackenproof.com/programs) |
 | HackerOne | [https://hackerone.com](https://hackerone.com) | USA | [@hacker0x01](https://x.com/hacker0x01) | Private + Public | Yes | [https://hackerone.com/leaderboard](https://hackerone.com/leaderboard) | [https://hackerone.com/directory/programs](https://hackerone.com/directory/programs) |
-| Hackrate | [https://hckrt.com](https://www.hckrt.com) | Hungary, Europe | [@hackrate](https://x.com/hackrate) | Private + Public | Yes | [https://www.hckrt.com/Profiles/Leaderboard](https://hckrt.com/Profiles/Leaderboard) | [https://www.hckrt.com/Catalog](https://hckrt.com/Catalog) |
+| Hackrate | [https://hckrt.com](https://hckrt.com) | Hungary | [@hackrate](https://x.com/hackrate) | Private + Public | Yes | [https://hckrt.com/Profiles/Leaderboard](https://hckrt.com/Profiles/Leaderboard) | [https://hckrt.com/Catalog](https://hckrt.com/Catalog) |
 | HACKTIFY | [https://hacktify.eu](https://hacktify.eu) | Central and Eastern Europe | [@HACKTIFY_](https://x.com/HACKTIFY_) | Private + Public | Yes | [https://hacktify.eu/en/leaderboard/](https://hacktify.eu/en/leaderboard/) | [https://hacktify.eu/en/public-programs/](https://hacktify.eu/en/public-programs/) |
 | Hashlock | [https://hashlock.com](https://hashlock.com) | Australia | [@HashLockAudit](https://x.com/HashLockAudit) | Private + Public | No | | [https://hashlock.com/bug-bounty](https://hashlock.com/bug-bounty) |
-| Hats | [https://hats.finance](https://hats.finance) | | [@HatsFinance](https://x.com/HatsFinance) | Public | Yes | | [https://app.hats.finance/vaults](https://app.hats.finance/vaults) |
+| Hats | [https://hats.finance](https://hats.finance) | | [@HatsFinance](https://x.com/HatsFinance) | Public | Yes | | |
 | HuntBug | [https://huntbug.com](https://huntbug.com) | USA | [@officialhuntbug](https://x.com/officialhuntbug) | Private + Public | Yes | [https://huntbug.com/leaderboard](https://huntbug.com/leaderboard) | |
 | Huntr | [https://huntr.dev](https://huntr.dev) | UK | [@huntrdev](https://x.com/huntrdev) | Private + Public | Yes | [https://huntr.dev/leaderboard](https://huntr.dev/leaderboard) | [https://huntr.dev/bounties/hacktivity](https://huntr.dev/bounties/hacktivity) |
 | Immunefi | [https://immunefi.com](https://immunefi.com) | | [@immunefi](https://x.com/immunefi) | Public | Yes | [https://immunefi.com/leaderboard/](https://immunefi.com/leaderboard/) | [https://immunefi.com/explore/](https://immunefi.com/explore/) |
@@ -58,40 +54,36 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Intigriti | [https://intigriti.com](https://intigriti.com) | Belgium | [@intigriti](https://x.com/intigriti) | Private + Public | Yes | [https://intigriti.com/leaderboard](https://intigriti.com/leaderboard) | [https://intigriti.com/programs](https://intigriti.com/programs) |
 | IssueHunt | [https://issuehunt.io](https://issuehunt.io) | Japan | [@IssueHunt](https://x.com/IssueHunt) | Private + Public | Yes | | [https://issuehunt.io/programs](https://issuehunt.io/programs) |
 | Nordic Defender | [https://nordicdefender.com](https://nordicdefender.com) | Sweden | [@nordicdefender](https://x.com/nordicdefender) | Private | | | |
-| ødin | [https://0din.ai/](https://0din.ai/) | USA | [@0dinai](https://x.com/0dinai) | | | | [https://0din.ai/scope](https://0din.ai/scope) |
-| Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Bangladesh | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | [https://openbugbounty.org/](https://openbugbounty.org/) | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
-| OWASP BLT | [https://bugheist.com](https://bugheist.com) | Global | [@oikitoikia](https://x.com/oikitoikia) | Public | Yes | | |
-| PatchDay | [https://patchday.io](https://patchday.io) | South Korea | [@patchday_io](https://x.com/patchday_io) | Private + Public | Yes | | [https://patchday.io](https://patchday.io) |
+| ødin | [https://0din.ai](https://0din.ai) | USA | [@0dinai](https://x.com/0dinai) | | | | [https://0din.ai/scope](https://0din.ai/scope) |
+| Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Bangladesh | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
+| PatchDay | [https://patchday.io](https://patchday.io) | South Korea | [@patchday_io](https://x.com/patchday_io) | Private + Public | Yes | | |
 | Patchstack | [https://patchstack.com](https://patchstack.com) | Estonia | [@paborza](https://x.com/paborza) | Public | Yes | [https://patchstack.com/database/leaderboard](https://patchstack.com/database/leaderboard) | [https://patchstack.com/database/vdp](https://patchstack.com/database/vdp) |
-| Pentabug | [https://pentabug.com](https://pentabug.com) | India | [@pentabug](https://x.com/pentabug) | Private | Yes | [https://pentabug.com](https://pentabug.com) | |
+| Pentabug | [https://pentabug.com](https://pentabug.com) | India | [@pentabug](https://x.com/pentabug) | Private | Yes | | |
 | Ravro | [https://ravro.ir](https://ravro.ir) | Iran | [@Ravro_ir](https://x.com/Ravro_ir) | Private + Public | Yes | [https://ravro.ir/reports](https://ravro.ir/reports) | [https://ravro.ir/companies](https://ravro.ir/companies) |
-| RedStorm | [https://redstorm.io](https://redstorm.io) | Indonesia | [@redstorm_io](https://x.com/redstorm_io) | Yes | Yes | | [https://redstorm.io/program](https://redstorm.io/program) |
+| RedStorm | [https://redstorm.io](https://redstorm.io) | Indonesia | [@redstorm_io](https://x.com/redstorm_io) | Private + Public | Yes | | [https://redstorm.io/program](https://redstorm.io/program) |
 | Remedy | [https://r.xyz](https://r.xyz) | Global | [@xyz_remedy](https://x.com/xyz_remedy) | Private + Public | No | | [https://hunt.r.xyz](https://hunt.r.xyz) |
-| safehats | [https://safehats.com](https://safehats.com/) | India | | Private + Public | Yes | [https://app.safehats.com/member/leaderboard](https://app.safehats.com/member/leaderboard) | |
-| Safevuln | [https://SafeVuln.com](https://SafeVuln.com) | Vietnam | | Public | Yes | [https://safevuln.com/leaderboard](https://safevuln.com/leaderboard) | [https://safevuln.com/programs](https://safevuln.com/programs) |
+| safehats | [https://safehats.com](https://safehats.com) | India | | Private + Public | Yes | [https://app.safehats.com/member/leaderboard](https://app.safehats.com/member/leaderboard) | |
+| Safevuln | [https://safevuln.com](https://safevuln.com) | Vietnam | | Public | Yes | [https://safevuln.com/leaderboard](https://safevuln.com/leaderboard) | [https://safevuln.com/programs](https://safevuln.com/programs) |
 | Secuna | [https://secuna.io](https://secuna.io) | Philippines | [@SecunaSecurity](https://x.com/SecunaSecurity) | Private | Yes | | |
-| Secur0 | [https://secur0.com](https://secur0.com) | Europe & Latam |  | Private + Public | Yes | [https://app.secur0.com/leaderboards](https://app.secur0.com/leaderboards) | [https://app.secur0.com/programs](https://app.secur0.com/programs) |
+| Secur0 | [https://secur0.com](https://secur0.com) | Europe & Latam | [@Secur00](https://x.com/Secur00) | Private + Public | Yes | [https://app.secur0.com/leaderboards](https://app.secur0.com/leaderboards) | [https://app.secur0.com/programs](https://app.secur0.com/programs) |
 | Sherlock | [https://sherlock.xyz](https://sherlock.xyz) | | [@sherlockdefi](https://x.com/sherlockdefi) | Public | Yes | [https://app.sherlock.xyz/audits/leaderboard](https://app.sherlock.xyz/audits/leaderboard) | [https://app.sherlock.xyz/audits/contests](https://app.sherlock.xyz/audits/contests) |
 | Singapore GovTech VDP | [https://www.tech.gov.sg/report-vulnerability/](https://www.tech.gov.sg/report-vulnerability/) | Singapore | [@GovTechSG](https://x.com/GovTechSG) | Public | No | | |
 | SlowMist | [https://slowmist.com](https://slowmist.com) | China | [@SlowMist_Team](https://x.com/SlowMist_Team) | Public | Yes | | |
-| Standoff 365 Bug Bounty | [https://bugbounty.standoff365.com](https://bugbounty.standoff365.com) | Russia | [@standoff365](https://x.com/standoff365) | Private + Public | Yes | [https://bugbounty.standoff365.com/en-US/rating/](https://bugbounty.standoff365.com/en-US/rating/) | [https://bugbounty.standoff365.com/en-US/](https://bugbounty.standoff365.com/en-US/) |
-| Swiss NCSC Bug Bounty | [https://www.ncsc.admin.ch](https://www.ncsc.admin.ch) | Switzerland | | Public | No | | |
+| Standoff 365 Bug Bounty | [https://bugbounty.standoff365.com](https://bugbounty.standoff365.com) | Russia | [@standoff365](https://x.com/standoff365) | Private + Public | Yes | | [https://bugbounty.standoff365.com/en-US/](https://bugbounty.standoff365.com/en-US/) |
 | Swarmnetics | [https://swarmnetics.com](https://swarmnetics.com) | Singapore | [@swarmnetics](https://x.com/swarmnetics) | Private | Yes | | |
+| Swiss NCSC Bug Bounty | [https://www.ncsc.admin.ch](https://www.ncsc.admin.ch) | Switzerland | | Public | No | | |
 | Synack | [https://synack.com](https://synack.com) | USA | [@synack](https://x.com/synack) | Private | Yes | | |
-| Teklabspace | [https://teklabspace.com](https://teklabspace.com) | Nigeria | [@teklabspace](https://x.com/teklabspace) | Public | Yes | [https://app.teklabspace.com/leaders-board/](https://app.teklabspace.com/leaders-board/) | [https://app.teklabspace.com/program/](https://app.teklabspace.com/program/) |
+| Teklabspace | [https://teklabspace.com](https://teklabspace.com) | Nigeria | [@teklabspace](https://x.com/teklabspace) | Public | Yes | | |
 | Testbirds | [https://testbirds.com](https://testbirds.com) | Germany | [@Testbirds](https://x.com/Testbirds) | QA + Bug Bounty | No | | |
 | thebugbounty | [https://thebugbounty.com](https://thebugbounty.com) | Malaysia | [@thebugbounty](https://x.com/thebugbounty) | Private | Yes | | |
-| Topcoder | [https://topcoder.com](https://topcoder.com) | USA | [@topcoder](https://x.com/topcoder) | Dev + Bug Bounty | Yes | [https://www.topcoder.com/community/member-statistics](https://www.topcoder.com/community/member-statistics) | [https://www.topcoder.com/challenges](https://www.topcoder.com/challenges) |
+| Topcoder | [https://topcoder.com](https://topcoder.com) | USA | [@topcoder](https://x.com/topcoder) | Dev + Bug Bounty | Yes | | [https://www.topcoder.com/challenges](https://www.topcoder.com/challenges) |
 | UK NCSC VDP | [https://www.ncsc.gov.uk](https://www.ncsc.gov.uk) | UK | [@NCSC](https://x.com/NCSC) | Public | No | | |
-| UAE National Bug Bounty | [https://bugbounty.ae](https://bugbounty.ae) | United Arab Emirates | | Private + Public | | | [https://bugbounty.ae](https://bugbounty.ae) |
-| v1bounty | [https://v1bounty.com](https://v1bounty.com) | Germany | [@v1bounty](https://x.com/v1bounty) | Public | Yes | | |
 | Vulbox | [https://vulbox.com](https://vulbox.com) | China | | Private + Public | Yes | [https://vulbox.com/top/season](https://vulbox.com/top/season) | [https://vulbox.com/projects/list](https://vulbox.com/projects/list) |
 | Vulnerability Lab | [https://vulnerability-lab.com](https://vulnerability-lab.com) | Germany | | Private + Public | Yes | [https://vulnerability-lab.com/hacktivity.php](https://vulnerability-lab.com/hacktivity.php) | |
 | Vulnscope | [https://vulnscope.com](https://vulnscope.com) | Chile | [@vulnscope](https://x.com/vulnscope) | Private | Yes | [https://vulnscope.com/hacker-ranking](https://vulnscope.com/hacker-ranking) | [https://vulnscope.com/programas](https://vulnscope.com/programas) |
-| Wordfence Bug Bounty | [https://www.wordfence.com/threat-intel/bug-bounty-program/](https://www.wordfence.com/threat-intel/bug-bounty-program/) | USA | [@wordfence](https://x.com/wordfence) | Public | No | | |
 | WhiteHub | [https://whitehub.net](https://whitehub.net) | Vietnam | [@CyStackSecurity](https://x.com/CyStackSecurity) | Private + Public | Yes | [https://whitehub.net/leaderboard](https://whitehub.net/leaderboard) | [https://whitehub.net/programs](https://whitehub.net/programs) |
+| Wordfence Bug Bounty | [https://www.wordfence.com/threat-intel/bug-bounty-program/](https://www.wordfence.com/threat-intel/bug-bounty-program/) | USA | [@wordfence](https://x.com/wordfence) | Public | No | | |
 | YesWeHack | [https://yeswehack.com](https://yeswehack.com) | France | [@yeswehack](https://x.com/yeswehack) | Private + Public | Yes | [https://yeswehack.com/ranking](https://yeswehack.com/ranking) | [https://yeswehack.com/programs](https://yeswehack.com/programs) |
 | Yogosha | [https://yogosha.com](https://yogosha.com) | France | [@yogoshaofficial](https://x.com/yogoshaofficial) | Private | Yes | | |
 | Zero Day Initiative | [https://zerodayinitiative.com](https://zerodayinitiative.com) | USA | [@thezdi](https://x.com/thezdi) | Public | Yes | [https://zerodayinitiative.com/advisories/published/](https://zerodayinitiative.com/advisories/published/) | |
 | Zerocopter | [https://zerocopter.com](https://zerocopter.com) | Netherlands | [@zerocopter](https://x.com/zerocopter) | Private | Yes | | |
-


### PR DESCRIPTION
## Summary

Comprehensive audit of all 89 platform entries — checked every URL for liveness, verified data accuracy, and fixed structural issues.

- **Removed 7 dead platforms** whose main sites are completely unreachable: BUGLOUD, Cyber3ra, EpicBounties, Hacckers, OWASP BLT (bugheist.com), v1bounty, UAE National Bug Bounty (bugbounty.ae)
- **Fixed data errors**: RedStorm "Program Types" was "Yes" instead of actual type; CertiK had duplicate leaderboard/programs URL; CISA VDP URL was 404
- **Added missing data**: Secur0 Twitter/X handle (@Secur00)
- **Removed 10+ dead/redundant sub-URLs**: Topcoder leaderboard (404), Standoff 365 rating (404), Teklabspace app URLs (unreachable), and others
- **Fixed alphabetical ordering**: 3 entries out of order (Cyber Army Indonesia, Swarmnetics, WhiteHub)
- **Normalized formatting**: SafeVuln mixed-case URL, Hackrate display/link mismatches, trailing slash inconsistencies

## Methodology

All 164 unique non-Twitter URLs were checked via HTTP with 10-second timeouts. Platforms returning 000 (connection failed/timeout) or 404 on their main site were flagged for removal. Platforms returning 403 were kept (likely WAF/anti-bot protection). Sub-URLs returning errors were removed while keeping the parent platform entry.

## Test plan

- [x] All remaining platform main URLs return 200 or known-WAF 403
- [x] No duplicate URLs in leaderboard/programs columns
- [x] Table is alphabetically ordered
- [x] RedStorm Program Types corrected
- [x] No display text / link target mismatches remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)