### PR TITLE
Platform directory audit + expansion (2026-06): +10, 8 corrections, 0 removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | BountyTeam | [https://www.bountyteam.com](https://www.bountyteam.com) | China | | Private + Public | Yes | | |
 | Bug Bounty Box | [https://bugbountybox.com](https://bugbountybox.com) | Kenya/Africa | | | | | |
 | Bug Bounty Switzerland | [https://bugbounty.ch](https://bugbounty.ch) | Switzerland | [@bugbounty_ch](https://x.com/bugbounty_ch) | Private + Public | Yes | | |
-| Bug Hunt | [https://bughunt.com.br](https://bughunt.com.br) | Brazil | | Private + Public | Yes | [https://bughunt.com.br/ranking-bughunters.html](https://bughunt.com.br/ranking-bughunters.html) | |
+| Bug Hunt | [https://bughunt.com.br](https://bughunt.com.br) | Brazil | [@bughuntoficial](https://x.com/bughuntoficial) | Private + Public | Yes | [https://bughunt.com.br/ranking-bughunters.html](https://bughunt.com.br/ranking-bughunters.html) | |
+| Bug Zero | [https://bugzero.io](https://bugzero.io) | Sri Lanka | [@BugZero_io](https://x.com/BugZero_io) | Private + Public | Yes | [https://bugzero.io/leaderboard](https://bugzero.io/leaderboard) | [https://bugzero.io/programs](https://bugzero.io/programs) |
+| BugBank | [https://www.bugbank.cn](https://www.bugbank.cn) | China | | Private + Public | Yes | | |
 | Bugbase | [https://bugbase.ai](https://bugbase.ai) | India | [@bugbase](https://x.com/bugbase) | Private + Public | Yes | [https://bugbase.ai/dashboard/leaderboard](https://bugbase.ai/dashboard/leaderboard) | [https://bugbase.ai/programs](https://bugbase.ai/programs) |
 | Bugbop | [https://bugbop.com](https://bugbop.com) | Australia | [@BugbopApp](https://x.com/BugbopApp) | Private + Public | Yes | | [https://bugbop.com/public-programs](https://bugbop.com/public-programs) |
 | BugBounter | [https://bugbounter.com](https://bugbounter.com) | US & Estonia & Turkey | [@bugbounterr](https://x.com/bugbounterr) | Private + Public | Yes | [https://app.bugbounter.com/public-top-bounters](https://app.bugbounter.com/public-top-bounters) | |
@@ -34,7 +36,7 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | CERT-In RVDCP | [https://www.cert-in.org.in/RVDCP.jsp](https://www.cert-in.org.in/RVDCP.jsp) | India | [@IndianCERT](https://x.com/IndianCERT) | Public | Yes | | |
 | Certora Contests | [https://www.certora.com/contests](https://www.certora.com/contests) | Global | [@certora](https://x.com/certora) | Public | Yes | [https://www.certora.com/leaderboard](https://www.certora.com/leaderboard) | [https://www.certora.com/contests](https://www.certora.com/contests) |
 | CERT Polska CVD | [https://cert.pl/en/cvd/](https://cert.pl/en/cvd/) | Poland | [@CERT_Polska_en](https://x.com/CERT_Polska_en) | Public | No | | [https://cert.pl/en/cve/](https://cert.pl/en/cve/) |
-| CISA VDP Platform | [https://www.cisa.gov/vdp](https://www.cisa.gov/vdp) | USA | [@CISAgov](https://x.com/CISAgov) | Public | No | | |
+| CISA VDP Platform | [https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform](https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform) | USA | [@CISAgov](https://x.com/CISAgov) | Public | No | | |
 | Cobalt | [https://cobalt.io](https://cobalt.io) | USA | [@cobalt_io](https://x.com/cobalt_io) | Private | Yes | [https://app.us.cobalt.io/pentesters](https://app.us.cobalt.io/pentesters) | |
 | Code4rena | [https://code4rena.com](https://code4rena.com) | | [@code4rena](https://x.com/code4rena) | Public | Yes | [https://code4rena.com/leaderboard](https://code4rena.com/leaderboard) | [https://code4rena.com/contests](https://code4rena.com/contests) |
 | CodeHawks | [https://codehawks.cyfrin.io](https://codehawks.cyfrin.io) | USA | [@CodeHawks](https://x.com/CodeHawks) | Private + Public | Yes | [https://codehawks.cyfrin.io/leaderboard](https://codehawks.cyfrin.io/leaderboard) | |
@@ -49,40 +51,48 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | DIVD | [https://www.divd.nl](https://www.divd.nl) | Netherlands | [@DIVDnl](https://x.com/DIVDnl) | Public | No | | |
 | Dvuln | [https://dvuln.com](https://dvuln.com) | Australia | [@d_vuln](https://x.com/d_vuln) | Private | Yes | | |
 | Federacy | [https://federacy.com](https://federacy.com) | USA | [@_federacy](https://x.com/_federacy) | Private + Public | Yes | | |
+| Find The Gap | [https://findthegap.co.kr/en](https://findthegap.co.kr/en) | South Korea | | Private + Public | No | | |
 | Findbug | [https://findbug.io](https://findbug.io) | Kosovo | [@Findbugks](https://x.com/Findbugks) | Private | Yes | | |
 | Gerobug | [https://gerobug.gerosecurity.com](https://gerobug.gerosecurity.com) | Indonesia | | Self-hosted | No | | |
 | GObugfree | [https://gobugfree.com](https://gobugfree.com) | Switzerland | [@gobugfree](https://x.com/gobugfree) | Private + Public | Yes | | [https://app.gobugfree.com/programs](https://app.gobugfree.com/programs) |
 | Gray Swan Arena | [https://app.grayswan.ai/arena](https://app.grayswan.ai/arena) | USA | [@GraySwanAI](https://x.com/GraySwanAI) | Public | Yes | [https://app.grayswan.ai/arena/leaderboard/global](https://app.grayswan.ai/arena/leaderboard/global) | [https://app.grayswan.ai/arena](https://app.grayswan.ai/arena) |
 | HackenProof | [https://hackenproof.com](https://hackenproof.com) | Estonia | [@HackenProof](https://x.com/HackenProof) | Private + Public | Yes | [https://hackenproof.com/leaderboard](https://hackenproof.com/leaderboard) | [https://hackenproof.com/programs](https://hackenproof.com/programs) |
 | HackerOne | [https://hackerone.com](https://hackerone.com) | USA | [@hacker0x01](https://x.com/hacker0x01) | Private + Public | Yes | [https://hackerone.com/leaderboard](https://hackerone.com/leaderboard) | [https://hackerone.com/directory/programs](https://hackerone.com/directory/programs) |
+| Hackr.fi | [https://www.hackr.fi](https://www.hackr.fi) | Finland | | Private + Public | No | | [https://www.hackr.fi/en/programs.html](https://www.hackr.fi/en/programs.html) |
 | Hackrate | [https://hckrt.com](https://hckrt.com) | Hungary | [@hackrate](https://x.com/hackrate) | Private + Public | Yes | [https://hckrt.com/Profiles/Leaderboard](https://hckrt.com/Profiles/Leaderboard) | [https://hckrt.com/Catalog](https://hckrt.com/Catalog) |
 | HACKTIFY | [https://hacktify.eu](https://hacktify.eu) | Central and Eastern Europe | [@HACKTIFY_](https://x.com/HACKTIFY_) | Private + Public | Yes | [https://hacktify.eu/en/leaderboard/](https://hacktify.eu/en/leaderboard/) | [https://hacktify.eu/en/public-programs/](https://hacktify.eu/en/public-programs/) |
 | Hashlock | [https://hashlock.com](https://hashlock.com) | Australia | [@HashLockAudit](https://x.com/HashLockAudit) | Private + Public | No | | [https://hashlock.com/bug-bounty](https://hashlock.com/bug-bounty) |
 | Hats | [https://hats.finance](https://hats.finance) | | [@HatsFinance](https://x.com/HatsFinance) | Public | Yes | | |
+| HITCON ZeroDay | [https://zeroday.hitcon.org](https://zeroday.hitcon.org) | Taiwan | [@HacksInTaiwan](https://x.com/HacksInTaiwan) | Private + Public | No | | [https://zeroday.hitcon.org/bug-bounty/list](https://zeroday.hitcon.org/bug-bounty/list) |
 | HuntBug | [https://huntbug.com](https://huntbug.com) | USA | [@officialhuntbug](https://x.com/officialhuntbug) | Private + Public | Yes | [https://huntbug.com/leaderboard](https://huntbug.com/leaderboard) | |
+| HuntersPay | [https://www.hunterspay.com.br](https://www.hunterspay.com.br) | Brazil | | Private + Public | No | | |
 | Huntr | [https://huntr.com](https://huntr.com) | UK | [@huntrdev](https://x.com/huntrdev) | Private + Public | Yes | [https://huntr.com/leaderboard](https://huntr.com/leaderboard) | [https://huntr.com/bounties/hacktivity](https://huntr.com/bounties/hacktivity) |
+| Huoxian | [https://www.huoxian.cn](https://www.huoxian.cn) | China | | Private + Public | Yes | | [https://www.huoxian.cn/project](https://www.huoxian.cn/project) |
 | Immunefi | [https://immunefi.com](https://immunefi.com) | | [@immunefi](https://x.com/immunefi) | Public | Yes | [https://immunefi.com/leaderboard/](https://immunefi.com/leaderboard/) | [https://immunefi.com/explore/](https://immunefi.com/explore/) |
 | Inspectiv | [https://inspectiv.com](https://inspectiv.com) | USA | [@inspectiv](https://x.com/inspectiv) | Private + Public | Yes | | |
 | Intigriti | [https://intigriti.com](https://intigriti.com) | Belgium | [@intigriti](https://x.com/intigriti) | Private + Public | Yes | [https://intigriti.com/leaderboard](https://intigriti.com/leaderboard) | [https://intigriti.com/programs](https://intigriti.com/programs) |
 | IssueHunt | [https://issuehunt.io](https://issuehunt.io) | Japan | [@IssueHunt](https://x.com/IssueHunt) | Private + Public | Yes | | [https://issuehunt.io/programs](https://issuehunt.io/programs) |
 | Japan Vulnerability Notes (JVN) | [https://jvn.jp/en/](https://jvn.jp/en/) | Japan | [@jpcert_en](https://x.com/jpcert_en) | Public | No | | [https://jvn.jp/en/nav/](https://jvn.jp/en/nav/) |
+| Kolahsefid | [https://www.kolahsefid.org](https://www.kolahsefid.org) | Iran | | Private + Public | No | | |
 | LRQA Nettitude | [https://bugbounty.nettitude.com](https://bugbounty.nettitude.com) | UK | [@NettitudeGroup](https://x.com/NettitudeGroup) | Private | | | |
 | NCIIPC RVDP | [https://nciipc.gov.in/RVDP.html](https://nciipc.gov.in/RVDP.html) | India | [@NCIIPC](https://x.com/NCIIPC) | Public | No | | |
+| NCSA Bug Bounty Programme | [https://hub.ncsa.gov.mv/resources/bug-bounty-program](https://hub.ncsa.gov.mv/resources/bug-bounty-program) | Maldives | | Public | Yes | | |
 | Nordic Defender | [https://nordicdefender.com](https://nordicdefender.com) | Sweden | [@nordicdefender](https://x.com/nordicdefender) | Private | | | |
-| ødin | [https://0din.ai](https://0din.ai) | USA | [@0dinai](https://x.com/0dinai) | | | | [https://0din.ai/scope](https://0din.ai/scope) |
-| Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Bangladesh | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
+| ødin | [https://0din.ai](https://0din.ai) | USA | [@0dinai](https://x.com/0dinai) | Public | Yes | [https://0din.ai/leaderboard](https://0din.ai/leaderboard) | [https://0din.ai/scope](https://0din.ai/scope) |
+| Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Global | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
 | PatchDay | [https://patchday.io](https://patchday.io) | South Korea | [@patchday_io](https://x.com/patchday_io) | Private + Public | Yes | | |
 | Patchstack | [https://patchstack.com](https://patchstack.com) | Estonia | [@paborza](https://x.com/paborza) | Public | Yes | [https://patchstack.com/database/leaderboard](https://patchstack.com/database/leaderboard) | [https://patchstack.com/database/vdp](https://patchstack.com/database/vdp) |
 | Pentabug | [https://pentabug.com](https://pentabug.com) | India | [@pentabug](https://x.com/pentabug) | Private | Yes | | |
+| Qatar Bug Bounty | [https://bugbounty.qa](https://bugbounty.qa) | Qatar | | Private + Public | No | | |
 | Ravro | [https://ravro.ir](https://ravro.ir) | Iran | [@Ravro_ir](https://x.com/Ravro_ir) | Private + Public | Yes | [https://ravro.ir/reports](https://ravro.ir/reports) | [https://ravro.ir/companies](https://ravro.ir/companies) |
 | RedStorm | [https://redstorm.io](https://redstorm.io) | Indonesia | [@redstorm_io](https://x.com/redstorm_io) | Private + Public | Yes | | [https://redstorm.io/program](https://redstorm.io/program) |
 | Remedy | [https://r.xyz](https://r.xyz) | Global | [@xyz_remedy](https://x.com/xyz_remedy) | Private + Public | No | | [https://hunt.r.xyz](https://hunt.r.xyz) |
 | safehats | [https://safehats.com](https://safehats.com) | India | | Private + Public | Yes | [https://app.safehats.com/member/leaderboard](https://app.safehats.com/member/leaderboard) | |
 | Safevuln | [https://safevuln.com](https://safevuln.com) | Vietnam | | Public | Yes | [https://safevuln.com/leaderboard](https://safevuln.com/leaderboard) | [https://safevuln.com/programs](https://safevuln.com/programs) |
-| Secuna | [https://secuna.io](https://secuna.io) | Philippines | [@SecunaSecurity](https://x.com/SecunaSecurity) | Private | Yes | | |
+| Secuna | [https://secuna.io](https://secuna.io) | Philippines | [@SecunaSecurity](https://x.com/SecunaSecurity) | Private + Public | Yes | | |
 | Secur0 | [https://secur0.com](https://secur0.com) | Europe & Latam | [@Secur00](https://x.com/Secur00) | Private + Public | Yes | [https://app.secur0.com/leaderboards](https://app.secur0.com/leaderboards) | [https://app.secur0.com/programs](https://app.secur0.com/programs) |
 | Secure3 | [https://secure3.io](https://secure3.io) | USA | [@Secure3io](https://x.com/Secure3io) | Private + Public | | | |
-| Sherlock | [https://sherlock.xyz](https://sherlock.xyz) | | [@sherlockdefi](https://x.com/sherlockdefi) | Public | Yes | [https://app.sherlock.xyz/audits/leaderboard](https://app.sherlock.xyz/audits/leaderboard) | [https://app.sherlock.xyz/audits/contests](https://app.sherlock.xyz/audits/contests) |
+| Sherlock | [https://sherlock.xyz](https://sherlock.xyz) | Global | [@sherlockdefi](https://x.com/sherlockdefi) | Public | Yes | [https://app.sherlock.xyz/audits/leaderboard](https://app.sherlock.xyz/audits/leaderboard) | [https://app.sherlock.xyz/audits/contests](https://app.sherlock.xyz/audits/contests) |
 | Singapore GovTech VDP | [https://www.tech.gov.sg/report-vulnerability/](https://www.tech.gov.sg/report-vulnerability/) | Singapore | [@GovTechSG](https://x.com/GovTechSG) | Public | No | | |
 | SlowMist | [https://slowmist.com](https://slowmist.com) | China | [@SlowMist_Team](https://x.com/SlowMist_Team) | Public | Yes | | |
 | Standoff 365 Bug Bounty | [https://bugbounty.standoff365.com](https://bugbounty.standoff365.com) | Russia | [@standoff365](https://x.com/standoff365) | Private + Public | Yes | | [https://bugbounty.standoff365.com/en-US/](https://bugbounty.standoff365.com/en-US/) |
@@ -97,10 +107,10 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | UK NCSC VDP | [https://www.ncsc.gov.uk](https://www.ncsc.gov.uk) | UK | [@NCSC](https://x.com/NCSC) | Public | No | | |
 | Vulbox | [https://vulbox.com](https://vulbox.com) | China | | Private + Public | Yes | [https://vulbox.com/top/season](https://vulbox.com/top/season) | [https://vulbox.com/projects/list](https://vulbox.com/projects/list) |
 | Vulnerability Lab | [https://vulnerability-lab.com](https://vulnerability-lab.com) | Germany | | Private + Public | Yes | [https://vulnerability-lab.com/hacktivity.php](https://vulnerability-lab.com/hacktivity.php) | |
-| Vulnscope | [https://vulnscope.com](https://vulnscope.com) | Chile | [@vulnscope](https://x.com/vulnscope) | Private | Yes | [https://vulnscope.com/hacker-ranking](https://vulnscope.com/hacker-ranking) | [https://vulnscope.com/programas](https://vulnscope.com/programas) |
+| Vulnscope | [https://vulnscope.com](https://vulnscope.com) | Chile | [@vulnscope](https://x.com/vulnscope) | Private + Public | Yes | [https://vulnscope.com/hacker-ranking](https://vulnscope.com/hacker-ranking) | [https://vulnscope.com/programas](https://vulnscope.com/programas) |
 | WhiteHub | [https://whitehub.net](https://whitehub.net) | Vietnam | [@CyStackSecurity](https://x.com/CyStackSecurity) | Private + Public | Yes | [https://whitehub.net/leaderboard](https://whitehub.net/leaderboard) | [https://whitehub.net/programs](https://whitehub.net/programs) |
 | Wordfence Bug Bounty | [https://www.wordfence.com/threat-intel/bug-bounty-program/](https://www.wordfence.com/threat-intel/bug-bounty-program/) | USA | [@wordfence](https://x.com/wordfence) | Public | No | | |
 | YesWeHack | [https://yeswehack.com](https://yeswehack.com) | France | [@yeswehack](https://x.com/yeswehack) | Private + Public | Yes | [https://yeswehack.com/ranking](https://yeswehack.com/ranking) | [https://yeswehack.com/programs](https://yeswehack.com/programs) |
-| Yogosha | [https://yogosha.com](https://yogosha.com) | France | [@yogoshaofficial](https://x.com/yogoshaofficial) | Private | Yes | | |
+| Yogosha | [https://yogosha.com](https://yogosha.com) | France | [@yogoshaofficial](https://x.com/yogoshaofficial) | Private | Yes | [https://yogosha.com/hackers/leaderboard/](https://yogosha.com/hackers/leaderboard/) | |
 | Zero Day Initiative | [https://zerodayinitiative.com](https://zerodayinitiative.com) | USA | [@thezdi](https://x.com/thezdi) | Public | Yes | [https://zerodayinitiative.com/advisories/published/](https://zerodayinitiative.com/advisories/published/) | |
 | Zerocopter | [https://zerocopter.com](https://zerocopter.com) | Netherlands | [@zerocopter](https://x.com/zerocopter) | Private | Yes | | |


### PR DESCRIPTION
## Summary

A full audit of every platform in the directory plus a discovery sweep for missing ones. This is **rebased on the current `main` (98 entries)** — the March/April audits (PRs #52–57) had already removed dead entries and added platforms, so this builds on top of that rather than reverting it.

**Net change: +10 platforms, 8 in-place corrections, 0 removals.** Every URL added or changed was probed live during this audit. A `403`/`451` (bot or geo block) was treated as *alive*; only `NXDOMAIN` / parked-domain / explicit shutdown was treated as dead.

## ➕ Additions (10) — all live-verified

| Platform | Region | Note |
|----------|--------|------|
| Bug Zero | Sri Lanka | National crowdsourced platform (incl. Sri Lanka CERT), 1200+ hunters |
| BugBank | China | 众测 crowdsourced-security platform |
| Find The Gap | South Korea | Korea's largest BBP (Samsung / LG U+ / Nexon) |
| Hackr.fi | Finland | Nordic bug-bounty-as-a-service (runs Finnish gov programs) |
| HITCON ZeroDay | Taiwan | VDP + bug-bounty run by Hacks In Taiwan / HITCON |
| HuntersPay | Brazil | Pay-per-finding crowdsourced platform (distinct from Bug Hunt) |
| Huoxian | China | 火线 crowdsourced-security platform |
| Kolahsefid | Iran | National competitive-debugger / bug-bounty platform |
| NCSA Bug Bounty Programme | Maldives | National VDP with Hall of Fame |
| Qatar Bug Bounty | Qatar | National multi-program platform |

## ✏️ Corrections (8)

- **Open Bug Bounty** — Region `Bangladesh` → `Global` (the value was erroneous/vandalized and was still live on `main`).
- **CISA VDP Platform** — URL `https://www.cisa.gov/vdp` now returns **404**; updated to the canonical service page `https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform`.
- **ødin** — filled Program Types (`Public`), Has Leaderboard (`Yes`), and Leaderboard URL (`https://0din.ai/leaderboard`, verified live).
- **Yogosha** — added Leaderboard URL (`https://yogosha.com/hackers/leaderboard/`, verified live).
- **Bug Hunt** — added X handle `@bughuntoficial`.
- **Sherlock** — Region → `Global`.
- **Vulnscope** — Program Types `Private` → `Private + Public` (runs public programs).
- **Secuna** — Program Types `Private` → `Private + Public` (runs public programs, e.g. the Coins.ph public bounty).

## 🚩 Flagged for maintainer review — NOT removed

These appear dead or dormant, but the rows were **left in place** for a maintainer to decide on removal:

- **Bug Bounty Box** — `bugbountybox.com` is NXDOMAIN across multiple resolvers (appears dead).
- **thebugbounty** — GoDaddy "Launching Soon" holding page (© 2024); never launched.
- **Teklabspace** — `app.teklabspace.com` is NXDOMAIN; homepage shows "0+" hackers (dormant).
- **Code4rena** — announced wind-down 2026-05-13; Immunefi absorbing clients/researchers (existing contests still finishing).
- **Crowdswarm** — app portal returns 502, TLS cert expired (dormant).
- **WhiteHub** — infrastructure live but "No programs found" (dormant).
- **Pentabug** — apex now redirects to parent company AppSecure; only the `dashboard.` subdomain is active.
- **SlowMist** — categorization note: an audit firm rather than a crowdsourced platform.

## 🔎 Candidate corrections (lower confidence — NOT applied)

Surfacing for confirmation; left unchanged in this PR:

- **AuditOne** — `@AuditOne_io` may no longer resolve (possibly `@AuditOne_DAO`).
- **Bugcrowd** — public-programs `/programs` 301-redirects to `/engagements`.
- **bugbounty.sa** — leaderboard may now be at `/public-leaderboard`.
- **Cyber Army Indonesia** — `cyberarmy.id/...` links redirect to a `.asia` 404; the live app is `app.cyberarmy.id`.
- **Cyscope** — region "Switzerland & Latam" may be Latam/Chile.
- **Huntr** — X handle may now be `@huntr_ai` after the AI/ML rebrand.
- **Zero Day Initiative / Zerocopter** — "Has Leaderboard: Yes" — no public researcher leaderboard found.

## 🚫 Considered but NOT added (couldn't confirm live)

WhiteJar (folded into Tryber — `whitejar.io` redirects to `tryber.me`), Bug Bounty Oman (`bugbountyoman.om` NXDOMAIN; `bugbounty.om` serves a NotFound page), SOBUG (origin returns 522), Bugdasht (DNS resolves but content geo-times-out), HackAPrompt (periodic competition series, not a standing submission platform).

## Note for maintainers (publishing pipeline)

The live page at `disclose.io/platforms/` renders from this repo as a Hugo **submodule** in `disclose.io`, currently pinned to `b4d0241` (Feb, 85 entries). That means the published page is **~2 months / ~13 entries behind this repo's `main`** — none of the already-merged April work is visible yet. Bumping the submodule pointer and rebuilding the site is needed for any of this (this PR included) to appear publicly.
