### PR TITLE
Add BBHunt Japan (bbhunt.jp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | 360 SRC | [https://src.360.net](https://src.360.net) | China | | Public + Private | | | |
 | Australian Government VDP | [https://www.homeaffairs.gov.au](https://www.homeaffairs.gov.au) | Australia | | Public | No | | |
 | AuditOne | [https://auditone.io](https://auditone.io) | Europe | [@AuditOne_io](https://x.com/AuditOne_io) | Private + Public | Yes | [https://www.auditone.io/bounty-activity](https://www.auditone.io/bounty-activity) | [https://www.auditone.io/bug-bounty](https://www.auditone.io/bug-bounty) |
+| BBHunt Japan | [https://bbhunt.jp](https://bbhunt.jp) | Japan | [@bbhuntjapan](https://x.com/bbhuntjapan) | Private + Public | | | |
 | BI.ZONE Bug Bounty | [https://bugbounty.bi.zone](https://bugbounty.bi.zone) | Russia | [@bizone](https://x.com/bizone) | Private + Public | Yes | [https://bugbounty.bi.zone/top-hackers](https://bugbounty.bi.zone/top-hackers) | [https://bugbounty.bi.zone/companies](https://bugbounty.bi.zone/companies) |
 | BountyTeam | [https://www.bountyteam.com](https://www.bountyteam.com) | China | | Private + Public | Yes | [https://www.bountyteam.com/leader-board](https://www.bountyteam.com/leader-board) | [https://www.bountyteam.com/bug-bounty-list](https://www.bountyteam.com/bug-bounty-list) |
 | Bug Bounty Switzerland | [https://bugbounty.ch](https://bugbounty.ch) | Switzerland | [@bugbounty_ch](https://x.com/bugbounty_ch) | Private + Public | Yes | | [https://www.bugbounty.ch/en/programs/](https://www.bugbounty.ch/en/programs/) |


### PR DESCRIPTION
Adds **BBHunt Japan** — submitted by Christakis Mina via hello@disclose.io (2026-06-30).

**Verification (all live-probed 2026-07-05):**
- `https://bbhunt.jp` → HTTP 200, nginx, real bug bounty platform content (bug bounty / vulnerability / researcher copy throughout)
- X handle `@bbhuntjapan` → site-link-confirmed (homepage links to x.com/bbhuntjapan; also GitHub + LinkedIn orgs under the same brand)
- Program Types: Private + Public (as submitted)
- Leaderboard / Public Programs URL cells left **blank** — probed /programs, /leaderboard, /en etc., all 404; no public board or listing found. Not guessed.

Table shape validated locally (111 rows × 8 cols).