### PR TITLE
Audit 2026-07 part 2: +12 verified platforms, remove Pentabug, fix Hackrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Butian | [https://butian.net](https://butian.net) | China | | Private + Public | Yes | [https://www.butian.net/Rank/whitehat](https://www.butian.net/Rank/whitehat) | [https://www.butian.net/Reward/plan/2](https://www.butian.net/Reward/plan/2) |
 | Cantina | [https://cantina.xyz](https://cantina.xyz) | USA | [@Cantinaxyz](https://x.com/Cantinaxyz) | Private + Public | Yes | [https://cantina.xyz/leaderboard](https://cantina.xyz/leaderboard) | [https://cantina.xyz/competitions](https://cantina.xyz/competitions) |
 | Capture The Bug | [https://capturethebug.xyz](https://capturethebug.xyz) | New Zealand | [@Capturethebugs](https://x.com/Capturethebugs) | Private | | | |
+| CCB Belgium CVD | [https://ccb.belgium.be/cert/vulnerability-reporting-ccb](https://ccb.belgium.be/cert/vulnerability-reporting-ccb) | Belgium | | Public | No | | |
 | CertiK Bug Bounty | [https://certik.com](https://certik.com) | USA | [@CertiK](https://x.com/CertiK) | Private + Public | Yes | [https://www.certik.com/products/bug-bounty](https://www.certik.com/products/bug-bounty) | |
 | CERT-In RVDCP | [https://www.cert-in.org.in/RVDCP.jsp](https://www.cert-in.org.in/RVDCP.jsp) | India | [@IndianCERT](https://x.com/IndianCERT) | Public | Yes | [https://www.cert-in.org.in/Hallof_Fame.jsp](https://www.cert-in.org.in/Hallof_Fame.jsp) | |
 | Certora Contests | [https://www.certora.com/contests](https://www.certora.com/contests) | Global | [@certora](https://x.com/certora) | Public | Yes | [https://www.certora.com/leaderboard](https://www.certora.com/leaderboard) | [https://www.certora.com/contests](https://www.certora.com/contests) |
@@ -66,6 +67,7 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Crowdswarm | [https://crowdswarm.io](https://crowdswarm.io) | United Arab Emirates | [@Crowdswarm1](https://x.com/Crowdswarm1) | Private + Public | Yes | | |
 | Cyber Army Indonesia | [https://www.cyberarmy.asia](https://www.cyberarmy.asia) | Indonesia | [@cyberarmyid](https://x.com/cyberarmyid) | Private + Public | | | |
 | Cyber3ra | [https://cyber3ra.com](https://cyber3ra.com) | India | | Private + Public | | | |
+| Cyberbay | [https://cyberbay.tech](https://cyberbay.tech) | Hong Kong | | Private + Public | | | |
 | CyberTalents | [https://cybertalents.com](https://cybertalents.com) | Middle East | [@CyberTalents](https://x.com/CyberTalents) | Public | Yes | [https://cybertalents.com/worldrank](https://cybertalents.com/worldrank) | [https://cybertalents.com/competitions](https://cybertalents.com/competitions) |
 | Cyscope | [https://cyscope.io](https://cyscope.io) | Switzerland & Latam | [@cy_scope](https://x.com/cy_scope) | Private + Public | Yes | | |
 | Detectify | [https://detectify.com](https://detectify.com) | Sweden | [@detectify](https://x.com/detectify) | Crowdsource (ASM) | Yes | | |
@@ -82,7 +84,7 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | HackenProof | [https://hackenproof.com](https://hackenproof.com) | Estonia | [@HackenProof](https://x.com/HackenProof) | Private + Public | Yes | [https://hackenproof.com/leaderboard](https://hackenproof.com/leaderboard) | [https://hackenproof.com/programs](https://hackenproof.com/programs) |
 | HackerOne | [https://hackerone.com](https://hackerone.com) | USA | [@hacker0x01](https://x.com/hacker0x01) | Private + Public | Yes | [https://hackerone.com/leaderboard](https://hackerone.com/leaderboard) | [https://hackerone.com/directory/programs](https://hackerone.com/directory/programs) |
 | Hackr.fi | [https://www.hackr.fi](https://www.hackr.fi) | Finland | [@hackrfi](https://x.com/hackrfi) | Private + Public | No | | [https://www.hackr.fi/en/programs.html](https://www.hackr.fi/en/programs.html) |
-| Hackrate | [https://hckrt.com](https://hckrt.com) | Hungary | [@hackrate](https://x.com/hackrate) | Private + Public | Yes | [https://hckrt.com/Profiles/Leaderboard](https://hckrt.com/Profiles/Leaderboard) | [https://hckrt.com/Catalog](https://hckrt.com/Catalog) |
+| Hackrate | [https://hckrt.com](https://hckrt.com) | Hungary | [@hackrate](https://x.com/hackrate) | Private + Public | Yes | | [https://hckrt.com/Catalog](https://hckrt.com/Catalog) |
 | HACKTIFY | [https://hacktify.eu](https://hacktify.eu) | Central and Eastern Europe | [@HACKTIFY_](https://x.com/HACKTIFY_) | Private + Public | Yes | [https://hacktify.eu/en/leaderboard/](https://hacktify.eu/en/leaderboard/) | [https://hacktify.eu/en/public-programs/](https://hacktify.eu/en/public-programs/) |
 | Hashlock | [https://hashlock.com](https://hashlock.com) | Australia | [@HashLockAudit](https://x.com/HashLockAudit) | Private + Public | No | | [https://hashlock.com/bug-bounty](https://hashlock.com/bug-bounty) |
 | Hats | [https://hats.finance](https://hats.finance) | | [@HatsFinance](https://x.com/HatsFinance) | Public | Yes | | |
@@ -96,15 +98,19 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Intigriti | [https://intigriti.com](https://intigriti.com) | Belgium | [@intigriti](https://x.com/intigriti) | Private + Public | Yes | [https://intigriti.com/leaderboard](https://intigriti.com/leaderboard) | [https://intigriti.com/programs](https://intigriti.com/programs) |
 | IssueHunt | [https://issuehunt.io](https://issuehunt.io) | Japan | [@IssueHunt](https://x.com/IssueHunt) | Private + Public | Yes | | [https://issuehunt.io/programs](https://issuehunt.io/programs) |
 | Japan Vulnerability Notes (JVN) | [https://jvn.jp/en/](https://jvn.jp/en/) | Japan | [@jpcert_en](https://x.com/jpcert_en) | Public | No | | [https://jvn.jp/en/nav/](https://jvn.jp/en/nav/) |
+| KISA KNVD | [https://knvd.krcert.or.kr](https://knvd.krcert.or.kr) | South Korea | | Public | No | | |
 | Kolahsefid | [https://www.kolahsefid.org](https://www.kolahsefid.org) | Iran | [@Kolaahsefid](https://x.com/Kolaahsefid) | Private + Public | No | | |
 | NCIIPC RVDP | [https://nciipc.gov.in/RVDP.html](https://nciipc.gov.in/RVDP.html) | India | [@NCIIPC](https://x.com/NCIIPC) | Public | No | | |
 | NCSA Bug Bounty Programme | [https://hub.ncsa.gov.mv/resources/bug-bounty-program](https://hub.ncsa.gov.mv/resources/bug-bounty-program) | Maldives | | Public | Yes | [https://hub.ncsa.gov.mv/bug-bounty/hall-of-fame](https://hub.ncsa.gov.mv/bug-bounty/hall-of-fame) | |
+| NCSC-FI CVD | [https://www.kyberturvallisuuskeskus.fi/en/report](https://www.kyberturvallisuuskeskus.fi/en/report) | Finland | | Public | No | | |
+| NCSC-NL CVD | [https://www.ncsc.nl/contact/kwetsbaarheid-melden](https://www.ncsc.nl/contact/kwetsbaarheid-melden) | Netherlands | | Public | No | | |
+| NKSC Lithuania CVD | [https://www.nksc.lt/pranesti-spraga.html](https://www.nksc.lt/pranesti-spraga.html) | Lithuania | | Public | No | | |
 | Nordic Defender | [https://nordicdefender.com](https://nordicdefender.com) | Sweden | [@nordicdefender](https://x.com/nordicdefender) | Private | | | |
 | ødin | [https://0din.ai](https://0din.ai) | USA | [@0dinai](https://x.com/0dinai) | Public | Yes | [https://0din.ai/leaderboard](https://0din.ai/leaderboard) | [https://0din.ai/scope](https://0din.ai/scope) |
 | Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Global | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
+| OpenBounty (Shentu) | [https://openbounty.shentu.org](https://openbounty.shentu.org) | | | Public | Yes | [https://openbounty.shentu.org/leaderboard](https://openbounty.shentu.org/leaderboard) | [https://openbounty.shentu.org/allBounties](https://openbounty.shentu.org/allBounties) |
 | PatchDay | [https://patchday.io](https://patchday.io) | South Korea | [@patchday_io](https://x.com/patchday_io) | Private + Public | Yes | | |
 | Patchstack | [https://patchstack.com](https://patchstack.com) | Estonia | [@paborza](https://x.com/paborza) | Public | Yes | [https://patchstack.com/database/leaderboard](https://patchstack.com/database/leaderboard) | [https://patchstack.com/database/vdp](https://patchstack.com/database/vdp) |
-| Pentabug | [https://pentabug.com](https://pentabug.com) | India | [@pentabug](https://x.com/pentabug) | Private | Yes | | |
 | Qatar Bug Bounty | [https://bugbounty.qa](https://bugbounty.qa) | Qatar | | Private + Public | No | | |
 | Ravro | [https://ravro.ir](https://ravro.ir) | Iran | [@Ravro_ir](https://x.com/Ravro_ir) | Private + Public | Yes | [https://ravro.ir/reports](https://ravro.ir/reports) | [https://ravro.ir/companies](https://ravro.ir/companies) |
 | RedStorm | [https://redstorm.io](https://redstorm.io) | Indonesia | [@redstorm_io](https://x.com/redstorm_io) | Private + Public | Yes | | [https://redstorm.io/program](https://redstorm.io/program) |
@@ -117,16 +123,20 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Sherlock | [https://sherlock.xyz](https://sherlock.xyz) | Global | [@sherlockdefi](https://x.com/sherlockdefi) | Public | Yes | [https://app.sherlock.xyz/audits/leaderboard](https://app.sherlock.xyz/audits/leaderboard) | [https://app.sherlock.xyz/audits/contests](https://app.sherlock.xyz/audits/contests) |
 | Singapore GovTech VDP | [https://www.tech.gov.sg/report-vulnerability/](https://www.tech.gov.sg/report-vulnerability/) | Singapore | [@GovTechSG](https://x.com/GovTechSG) | Public | No | | |
 | SlowMist | [https://slowmist.com](https://slowmist.com) | China | [@SlowMist_Team](https://x.com/SlowMist_Team) | Public | Yes | | [https://slowmist.io/bug-bounty.html](https://slowmist.io/bug-bounty.html) |
+| SSD Secure Disclosure | [https://ssd-disclosure.com](https://ssd-disclosure.com) | Israel | [@SecuriTeam_SSD](https://x.com/SecuriTeam_SSD) | Public | No | | |
 | Standoff 365 Bug Bounty | [https://bugbounty.standoff365.com](https://bugbounty.standoff365.com) | Russia | [@standoff365](https://x.com/standoff365) | Private + Public | Yes | [https://standoff365.com/en-US/ratings/](https://standoff365.com/en-US/ratings/) | [https://bugbounty.standoff365.com/en-US/](https://bugbounty.standoff365.com/en-US/) |
 | Swarmnetics | [https://swarmnetics.com](https://swarmnetics.com) | Singapore | [@swarmnetics](https://x.com/swarmnetics) | Private | Yes | | |
 | Swiss NCSC Bug Bounty | [https://www.ncsc.admin.ch](https://www.ncsc.admin.ch) | Switzerland | | Public | No | | |
 | Synack | [https://synack.com](https://synack.com) | USA | [@synack](https://x.com/synack) | Private | Yes | | |
+| Taiwan Vulnerability Note (TVN) | [https://www.twcert.org.tw/en/np-138-2.html](https://www.twcert.org.tw/en/np-138-2.html) | Taiwan | [@TWCERTCC](https://x.com/TWCERTCC) | Public | No | | [https://www.twcert.org.tw/en/lp-139-2.html](https://www.twcert.org.tw/en/lp-139-2.html) |
 | Teklabspace | [https://teklabspace.com](https://teklabspace.com) | Nigeria | [@teklabspace](https://x.com/teklabspace) | Public | Yes | | |
 | Testbirds | [https://testbirds.com](https://testbirds.com) | Germany | [@Testbirds](https://x.com/Testbirds) | QA + Bug Bounty | No | | |
 | Topcoder | [https://topcoder.com](https://topcoder.com) | USA | [@topcoder](https://x.com/topcoder) | Dev + Bug Bounty | Yes | [https://www.topcoder.com/community/statistics](https://www.topcoder.com/community/statistics) | [https://www.topcoder.com/challenges](https://www.topcoder.com/challenges) |
 | TrustLine | [https://www.trustline.sa](https://www.trustline.sa) | Saudi Arabia | [@trustlineSec](https://x.com/trustlineSec) | Private + Public | | | |
 | TumarOne | [https://tumar.one](https://tumar.one) | Kazakhstan | | Private + Public | Yes | [https://tumar.one/leaderboard](https://tumar.one/leaderboard) | [https://tumar.one/#for-bug-hunters](https://tumar.one/#for-bug-hunters) |
+| UAE National Bug Bounty | [https://bugbounty.ae](https://bugbounty.ae) | United Arab Emirates | | Private | | | |
 | UK NCSC VDP | [https://www.ncsc.gov.uk](https://www.ncsc.gov.uk) | UK | [@NCSC](https://x.com/NCSC) | Public | No | | |
+| UzHunter | [https://uzhunter.com](https://uzhunter.com) | Uzbekistan | | | | | |
 | Vulbox | [https://vulbox.com](https://vulbox.com) | China | | Private + Public | Yes | [https://vulbox.com/top/season](https://vulbox.com/top/season) | [https://vulbox.com/projects/list](https://vulbox.com/projects/list) |
 | Vulnerability Lab | [https://vulnerability-lab.com](https://vulnerability-lab.com) | Germany | | Private + Public | Yes | [https://vulnerability-lab.com/hacktivity.php](https://vulnerability-lab.com/hacktivity.php) | [https://www.vulnerability-lab.com/list-of-bug-bounty-programs.php](https://www.vulnerability-lab.com/list-of-bug-bounty-programs.php) |
 | Vulnscope | [https://vulnscope.com](https://vulnscope.com) | Chile | [@vulnscope](https://x.com/vulnscope) | Private + Public | Yes | [https://vulnscope.com/hacker-ranking](https://vulnscope.com/hacker-ranking) | [https://vulnscope.com/programas](https://vulnscope.com/programas) |
@@ -136,3 +146,4 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Yogosha | [https://yogosha.com](https://yogosha.com) | France | [@yogoshaofficial](https://x.com/yogoshaofficial) | Private | Yes | [https://yogosha.com/hackers/leaderboard/](https://yogosha.com/hackers/leaderboard/) | |
 | Zero Day Initiative | [https://zerodayinitiative.com](https://zerodayinitiative.com) | USA | [@thezdi](https://x.com/thezdi) | Public | Yes | [https://zerodayinitiative.com/advisories/published/](https://zerodayinitiative.com/advisories/published/) | |
 | Zerocopter | [https://zerocopter.com](https://zerocopter.com) | Netherlands | [@zerocopter](https://x.com/zerocopter) | Private | Yes | | |
+| ZeroDay Test | [https://zerodaytest.com](https://zerodaytest.com) | Bangladesh | [@Zer0day_t3st](https://x.com/Zer0day_t3st) | | | | |


### PR DESCRIPTION
Completes the audit started last night (a17f170 / 787ec6f / f576d04) + a systematic discovery sweep for missing platforms.

## Added (12) — every value live-verified 2026-07-05, X handles only where site-link-confirmed
| Platform | Class | Verification |
|---|---|---|
| CCB Belgium CVD | national CVD (statutory safe harbor, NIS2 law) | full policy page read in real Chrome (curl is bot-walled) |
| NCSC-FI CVD | national CVD (Traficom) | 200, report+vulnerability content |
| NCSC-NL CVD | national CVD | 200, 41× kwetsbaarheid/CVD content |
| NKSC Lithuania CVD | national CVD (Art. 25 Cybersecurity Law) | dedicated report form verified in Chrome (Cloudflare-walled for curl) |
| KISA KNVD | KR national vuln reporting/reward | knvd.krcert.or.kr 200, 취약점 content |
| Taiwan Vulnerability Note (TVN) | TWCERT/CC coordinated disclosure (JVN class) | EN TVN pages 200 (51× TVN); tvn. subdomain geo-limited, so canonical EN URL used; @TWCERTCC on-site |
| Cyberbay | HK commercial platform | 200, bug-bounty content ×11, campaign page ×43 bounty |
| UAE National Bug Bounty | UAE Cyber Security Council national program | bugbounty.ae 200 + FAQ (33× researcher); vetted/private model → Private |
| UzHunter | UZ platform | 200, bug bounty + hacker content; program-type unstated → left blank |
| ZeroDay Test | BD crowdsourced platform | 200, 5× Bug Bounty; @Zer0day_t3st linked on site |
| OpenBounty (Shentu) | web3 | main/allBounties/leaderboard all 200. Note: CertiK-adjacent lineage + 2024 program-relisting controversy (protos.com) — listed without endorsement, same as other entries |
| SSD Secure Disclosure | multi-vendor acquisition + coordinated disclosure (ZDI class) | 200, submit→pay→publish pipeline; @SecuriTeam_SSD on-site |

## Removed (1)
- **Pentabug** — pentabug.com 301s to appsecure.security (pentest consultancy); platform gone. Flagged in the 2026-06 audit, now confirmed.

## Fixed (1)
- **Hackrate** — /Profiles/Leaderboard now redirects every visitor to a B2C login; URL dropped (same treatment as safehats last night).

## Verified-kept (previously flagged)
Crowdswarm (recovered from June's 502 — 200 + real platform content), Teklabspace, WhiteHub, Code4rena (200 incl. leaderboard/programs), Butian, NCIIPC, BugBounty.ru (geo-fenced from this vantage; alive per the 403/451 rule).

## Deferred (recorded, not added)
Oqdo'ppi (UZ, JS SPA — content unverifiable this pass), BugRank (VN, Polaris bot-wall), Bugdasht (IR, geo-unreachable), VulneraPro (Oi/BR — telco managed service, fails the platform bar).

Local table validation: 121 data rows × 8 cols.