### PR TITLE
Restructure into 6 category sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p>
 <a href="LICENSE"><img src="https://img.shields.io/github/license/disclose/bug-bounty-platforms?color=5B3AB6&label=license" alt="CC0 1.0"></a>
 <a href="https://disclose.io/platforms/"><img src="https://img.shields.io/badge/browse-disclose.io%2Fplatforms-5B3AB6" alt="Browse at disclose.io/platforms"></a>
-<img src="https://img.shields.io/badge/tracked-109%2B%20platforms-5B3AB6" alt="109+ platforms tracked">
+<img src="https://img.shields.io/badge/tracked-121%2B%20platforms-5B3AB6" alt="121+ platforms tracked">
 <a href="https://github.com/disclose/bug-bounty-platforms/graphs/contributors"><img src="https://img.shields.io/github/contributors/disclose/bug-bounty-platforms?color=5B3AB6" alt="Contributors"></a>
 <a href="https://github.com/disclose/bug-bounty-platforms/edit/main/README.md"><img src="https://img.shields.io/badge/PRs-welcome-5B3AB6" alt="PRs welcome"></a>
 </p>
@@ -24,11 +24,91 @@ An ongoing community-powered collection of all known bug bounty platforms, vulne
 
 Is there a platform or detail missing, or have you spotted something wrong? This site is open source. [Improve this page](https://github.com/disclose/bug-bounty-platforms/edit/main/README.md)!
 
+## Adding or moving an entry
+
+Every platform lives in exactly **one** category section below. If a platform fits more than one, the first match in this precedence order wins: **Government & public-interest → AI → Web3 → Brokered disclosure → Ecosystem-specific → General**. If a category ever drops below two entries, fold it into General. Keep rows alphabetical within their section, and keep the 8-column format (CI enforces the column count).
+
+<!-- platforms:start -->
+
+**Jump to:** [Government and public-interest programs](#government-and-public-interest-programs) · [Web3 and smart-contract platforms](#web3-and-smart-contract-platforms) · [AI and LLM security platforms](#ai-and-llm-security-platforms) · [Vulnerability acquisition and brokered disclosure](#vulnerability-acquisition-and-brokered-disclosure) · [Ecosystem-specific platforms](#ecosystem-specific-platforms) · [General crowdsourced platforms](#general-crowdsourced-platforms)
+
+## Government and public-interest programs
+
+| Platform Name | URL | Region | Twitter/X | Program Types | Has Leaderboard | Leaderboard URL | Public Programs URL |
+|---------------|-----|--------|-----------|---------------|-----------------|-----------------|---------------------|
+| Australian Government VDP | [https://www.homeaffairs.gov.au](https://www.homeaffairs.gov.au) | Australia | | Public | No | | |
+| bugbounty.sa | [https://bugbounty.sa](https://bugbounty.sa) | Saudi Arabia | [@BugBountySA](https://x.com/BugBountySA) | Private | Yes | [https://bugbounty.sa/leaderboard](https://bugbounty.sa/leaderboard) | |
+| CCB Belgium CVD | [https://ccb.belgium.be/cert/vulnerability-reporting-ccb](https://ccb.belgium.be/cert/vulnerability-reporting-ccb) | Belgium | | Public | No | | |
+| CERT Polska CVD | [https://cert.pl/en/cvd/](https://cert.pl/en/cvd/) | Poland | [@CERT_Polska_en](https://x.com/CERT_Polska_en) | Public | No | | [https://cert.pl/en/cve/](https://cert.pl/en/cve/) |
+| CERT-In RVDCP | [https://www.cert-in.org.in/RVDCP.jsp](https://www.cert-in.org.in/RVDCP.jsp) | India | [@IndianCERT](https://x.com/IndianCERT) | Public | Yes | [https://www.cert-in.org.in/Hallof_Fame.jsp](https://www.cert-in.org.in/Hallof_Fame.jsp) | |
+| CISA VDP Platform | [https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform](https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform) | USA | [@CISAgov](https://x.com/CISAgov) | Public | No | | |
+| DIVD | [https://www.divd.nl](https://www.divd.nl) | Netherlands | [@DIVDnl](https://x.com/DIVDnl) | Public | No | | |
+| HITCON ZeroDay | [https://zeroday.hitcon.org](https://zeroday.hitcon.org) | Taiwan | [@HacksInTaiwan](https://x.com/HacksInTaiwan) | Private + Public | No | | [https://zeroday.hitcon.org/bug-bounty/list](https://zeroday.hitcon.org/bug-bounty/list) |
+| Japan Vulnerability Notes (JVN) | [https://jvn.jp/en/](https://jvn.jp/en/) | Japan | [@jpcert_en](https://x.com/jpcert_en) | Public | No | | [https://jvn.jp/en/nav/](https://jvn.jp/en/nav/) |
+| KISA KNVD | [https://knvd.krcert.or.kr](https://knvd.krcert.or.kr) | South Korea | | Public | No | | |
+| NCIIPC RVDP | [https://nciipc.gov.in/RVDP.html](https://nciipc.gov.in/RVDP.html) | India | [@NCIIPC](https://x.com/NCIIPC) | Public | No | | |
+| NCSA Bug Bounty Programme | [https://hub.ncsa.gov.mv/resources/bug-bounty-program](https://hub.ncsa.gov.mv/resources/bug-bounty-program) | Maldives | | Public | Yes | [https://hub.ncsa.gov.mv/bug-bounty/hall-of-fame](https://hub.ncsa.gov.mv/bug-bounty/hall-of-fame) | |
+| NCSC-FI CVD | [https://www.kyberturvallisuuskeskus.fi/en/report](https://www.kyberturvallisuuskeskus.fi/en/report) | Finland | | Public | No | | |
+| NCSC-NL CVD | [https://www.ncsc.nl/contact/kwetsbaarheid-melden](https://www.ncsc.nl/contact/kwetsbaarheid-melden) | Netherlands | | Public | No | | |
+| NKSC Lithuania CVD | [https://www.nksc.lt/pranesti-spraga.html](https://www.nksc.lt/pranesti-spraga.html) | Lithuania | | Public | No | | |
+| Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Global | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
+| Qatar Bug Bounty | [https://bugbounty.qa](https://bugbounty.qa) | Qatar | | Private + Public | No | | |
+| Singapore GovTech VDP | [https://www.tech.gov.sg/report-vulnerability/](https://www.tech.gov.sg/report-vulnerability/) | Singapore | [@GovTechSG](https://x.com/GovTechSG) | Public | No | | |
+| Swiss NCSC Bug Bounty | [https://www.ncsc.admin.ch](https://www.ncsc.admin.ch) | Switzerland | | Public | No | | |
+| Taiwan Vulnerability Note (TVN) | [https://www.twcert.org.tw/en/np-138-2.html](https://www.twcert.org.tw/en/np-138-2.html) | Taiwan | [@TWCERTCC](https://x.com/TWCERTCC) | Public | No | | [https://www.twcert.org.tw/en/lp-139-2.html](https://www.twcert.org.tw/en/lp-139-2.html) |
+| UAE National Bug Bounty | [https://bugbounty.ae](https://bugbounty.ae) | United Arab Emirates | | Private | | | |
+| UK NCSC VDP | [https://www.ncsc.gov.uk](https://www.ncsc.gov.uk) | UK | [@NCSC](https://x.com/NCSC) | Public | No | | |
+
+## Web3 and smart-contract platforms
+
+| Platform Name | URL | Region | Twitter/X | Program Types | Has Leaderboard | Leaderboard URL | Public Programs URL |
+|---------------|-----|--------|-----------|---------------|-----------------|-----------------|---------------------|
+| AuditOne | [https://auditone.io](https://auditone.io) | Europe | [@AuditOne_io](https://x.com/AuditOne_io) | Private + Public | Yes | [https://www.auditone.io/bounty-activity](https://www.auditone.io/bounty-activity) | [https://www.auditone.io/bug-bounty](https://www.auditone.io/bug-bounty) |
+| BugRap | [https://bugrap.io](https://bugrap.io) | | [@BugRap_Team](https://x.com/BugRap_Team) | Public | Yes | [https://bugrap.io/whiteHats](https://bugrap.io/whiteHats) | [https://bugrap.io/bounties](https://bugrap.io/bounties) |
+| Cantina | [https://cantina.xyz](https://cantina.xyz) | USA | [@Cantinaxyz](https://x.com/Cantinaxyz) | Private + Public | Yes | [https://cantina.xyz/leaderboard](https://cantina.xyz/leaderboard) | [https://cantina.xyz/competitions](https://cantina.xyz/competitions) |
+| CertiK Bug Bounty | [https://certik.com](https://certik.com) | USA | [@CertiK](https://x.com/CertiK) | Private + Public | Yes | [https://www.certik.com/products/bug-bounty](https://www.certik.com/products/bug-bounty) | |
+| Certora Contests | [https://www.certora.com/contests](https://www.certora.com/contests) | Global | [@certora](https://x.com/certora) | Public | Yes | [https://www.certora.com/leaderboard](https://www.certora.com/leaderboard) | [https://www.certora.com/contests](https://www.certora.com/contests) |
+| Code4rena | [https://code4rena.com](https://code4rena.com) | | [@code4rena](https://x.com/code4rena) | Public | Yes | [https://code4rena.com/leaderboard](https://code4rena.com/leaderboard) | [https://code4rena.com/contests](https://code4rena.com/contests) |
+| CodeHawks | [https://codehawks.cyfrin.io](https://codehawks.cyfrin.io) | USA | [@CodeHawks](https://x.com/CodeHawks) | Private + Public | Yes | [https://codehawks.cyfrin.io/leaderboard](https://codehawks.cyfrin.io/leaderboard) | [https://codehawks.cyfrin.io/contests](https://codehawks.cyfrin.io/contests) |
+| HackenProof | [https://hackenproof.com](https://hackenproof.com) | Estonia | [@HackenProof](https://x.com/HackenProof) | Private + Public | Yes | [https://hackenproof.com/leaderboard](https://hackenproof.com/leaderboard) | [https://hackenproof.com/programs](https://hackenproof.com/programs) |
+| Hashlock | [https://hashlock.com](https://hashlock.com) | Australia | [@HashLockAudit](https://x.com/HashLockAudit) | Private + Public | No | | [https://hashlock.com/bug-bounty](https://hashlock.com/bug-bounty) |
+| Hats | [https://hats.finance](https://hats.finance) | | [@HatsFinance](https://x.com/HatsFinance) | Public | Yes | | |
+| Immunefi | [https://immunefi.com](https://immunefi.com) | | [@immunefi](https://x.com/immunefi) | Public | Yes | [https://immunefi.com/leaderboard/](https://immunefi.com/leaderboard/) | [https://immunefi.com/explore/](https://immunefi.com/explore/) |
+| OpenBounty (Shentu) | [https://openbounty.shentu.org](https://openbounty.shentu.org) | | | Public | Yes | [https://openbounty.shentu.org/leaderboard](https://openbounty.shentu.org/leaderboard) | [https://openbounty.shentu.org/allBounties](https://openbounty.shentu.org/allBounties) |
+| Remedy | [https://r.xyz](https://r.xyz) | Global | [@xyz_remedy](https://x.com/xyz_remedy) | Private + Public | No | | [https://hunt.r.xyz](https://hunt.r.xyz) |
+| Secure3 | [https://secure3.io](https://secure3.io) | USA | [@Secure3io](https://x.com/Secure3io) | Private + Public | | | |
+| Sherlock | [https://sherlock.xyz](https://sherlock.xyz) | Global | [@sherlockdefi](https://x.com/sherlockdefi) | Public | Yes | [https://app.sherlock.xyz/audits/leaderboard](https://app.sherlock.xyz/audits/leaderboard) | [https://app.sherlock.xyz/audits/contests](https://app.sherlock.xyz/audits/contests) |
+| SlowMist | [https://slowmist.com](https://slowmist.com) | China | [@SlowMist_Team](https://x.com/SlowMist_Team) | Public | Yes | | [https://slowmist.io/bug-bounty.html](https://slowmist.io/bug-bounty.html) |
+
+## AI and LLM security platforms
+
+| Platform Name | URL | Region | Twitter/X | Program Types | Has Leaderboard | Leaderboard URL | Public Programs URL |
+|---------------|-----|--------|-----------|---------------|-----------------|-----------------|---------------------|
+| Gray Swan Arena | [https://app.grayswan.ai/arena](https://app.grayswan.ai/arena) | USA | [@GraySwanAI](https://x.com/GraySwanAI) | Public | Yes | [https://app.grayswan.ai/arena/leaderboard/global](https://app.grayswan.ai/arena/leaderboard/global) | [https://app.grayswan.ai/arena](https://app.grayswan.ai/arena) |
+| HackAPrompt | [https://www.hackaprompt.com](https://www.hackaprompt.com) | USA | | Public | Yes | [https://www.hackaprompt.com/leaderboard](https://www.hackaprompt.com/leaderboard) | |
+| Huntr | [https://huntr.com](https://huntr.com) | UK | [@huntrdev](https://x.com/huntrdev) | Private + Public | Yes | [https://huntr.com/leaderboard](https://huntr.com/leaderboard) | [https://huntr.com/bounties/hacktivity](https://huntr.com/bounties/hacktivity) |
+| ødin | [https://0din.ai](https://0din.ai) | USA | [@0dinai](https://x.com/0dinai) | Public | Yes | [https://0din.ai/leaderboard](https://0din.ai/leaderboard) | [https://0din.ai/scope](https://0din.ai/scope) |
+
+## Vulnerability acquisition and brokered disclosure
+
+| Platform Name | URL | Region | Twitter/X | Program Types | Has Leaderboard | Leaderboard URL | Public Programs URL |
+|---------------|-----|--------|-----------|---------------|-----------------|-----------------|---------------------|
+| SSD Secure Disclosure | [https://ssd-disclosure.com](https://ssd-disclosure.com) | Israel | [@SecuriTeam_SSD](https://x.com/SecuriTeam_SSD) | Public | No | | |
+| Zero Day Initiative | [https://zerodayinitiative.com](https://zerodayinitiative.com) | USA | [@thezdi](https://x.com/thezdi) | Public | Yes | [https://zerodayinitiative.com/advisories/published/](https://zerodayinitiative.com/advisories/published/) | |
+
+## Ecosystem-specific platforms
+
+| Platform Name | URL | Region | Twitter/X | Program Types | Has Leaderboard | Leaderboard URL | Public Programs URL |
+|---------------|-----|--------|-----------|---------------|-----------------|-----------------|---------------------|
+| IssueHunt | [https://issuehunt.io](https://issuehunt.io) | Japan | [@IssueHunt](https://x.com/IssueHunt) | Private + Public | Yes | | [https://issuehunt.io/programs](https://issuehunt.io/programs) |
+| Patchstack | [https://patchstack.com](https://patchstack.com) | Estonia | [@paborza](https://x.com/paborza) | Public | Yes | [https://patchstack.com/database/leaderboard](https://patchstack.com/database/leaderboard) | [https://patchstack.com/database/vdp](https://patchstack.com/database/vdp) |
+| Wordfence Bug Bounty | [https://www.wordfence.com/threat-intel/bug-bounty-program/](https://www.wordfence.com/threat-intel/bug-bounty-program/) | USA | [@wordfence](https://x.com/wordfence) | Public | No | | |
+
+## General crowdsourced platforms
+
 | Platform Name | URL | Region | Twitter/X | Program Types | Has Leaderboard | Leaderboard URL | Public Programs URL |
 |---------------|-----|--------|-----------|---------------|-----------------|-----------------|---------------------|
 | 360 SRC | [https://src.360.net](https://src.360.net) | China | | Public + Private | | | |
-| Australian Government VDP | [https://www.homeaffairs.gov.au](https://www.homeaffairs.gov.au) | Australia | | Public | No | | |
-| AuditOne | [https://auditone.io](https://auditone.io) | Europe | [@AuditOne_io](https://x.com/AuditOne_io) | Private + Public | Yes | [https://www.auditone.io/bounty-activity](https://www.auditone.io/bounty-activity) | [https://www.auditone.io/bug-bounty](https://www.auditone.io/bug-bounty) |
 | BBHunt Japan | [https://bbhunt.jp](https://bbhunt.jp) | Japan | [@bbhuntjapan](https://x.com/bbhuntjapan) | Private + Public | | | |
 | BI.ZONE Bug Bounty | [https://bugbounty.bi.zone](https://bugbounty.bi.zone) | Russia | [@bizone](https://x.com/bizone) | Private + Public | Yes | [https://bugbounty.bi.zone/top-hackers](https://bugbounty.bi.zone/top-hackers) | [https://bugbounty.bi.zone/companies](https://bugbounty.bi.zone/companies) |
 | BountyTeam | [https://www.bountyteam.com](https://www.bountyteam.com) | China | | Private + Public | Yes | [https://www.bountyteam.com/leader-board](https://www.bountyteam.com/leader-board) | [https://www.bountyteam.com/bug-bounty-list](https://www.bountyteam.com/bug-bounty-list) |
@@ -42,26 +122,15 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | BugBounty.am | [https://bugbounty.am](https://bugbounty.am) | Armenia | | Private + Public | | | |
 | bugbounty.jp | [https://bugbounty.jp](https://bugbounty.jp) | Japan | | Private + Public | | | [https://bugbounty.jp/en/](https://bugbounty.jp/en/) |
 | BugBounty.ru | [https://bugbounty.ru](https://bugbounty.ru) | Russia | | Private + Public | | | [https://bugbounty.ru/app/programs](https://bugbounty.ru/app/programs) |
-| bugbounty.sa | [https://bugbounty.sa](https://bugbounty.sa) | Saudi Arabia | [@BugBountySA](https://x.com/BugBountySA) | Private | Yes | [https://bugbounty.sa/leaderboard](https://bugbounty.sa/leaderboard) | |
 | Bugcrowd | [https://bugcrowd.com](https://bugcrowd.com) | USA | [@bugcrowd](https://x.com/bugcrowd) | Private + Public | Yes | [https://bugcrowd.com/leaderboard](https://bugcrowd.com/leaderboard) | [https://bugcrowd.com/programs](https://bugcrowd.com/programs) |
 | Buglab | [https://buglab.io](https://buglab.io) | Singapore | [@joinbuglab](https://x.com/joinbuglab) | Private + Public | Yes | | |
 | Bugloud | [https://bugloud.com](https://bugloud.com) | United Arab Emirates | | Private + Public | Yes | [https://bugloud.com/leaderboard](https://bugloud.com/leaderboard) | [https://bugloud.com/programs](https://bugloud.com/programs) |
 | BugRakshak | [https://www.bugrakshak.com](https://www.bugrakshak.com) | India | | Private + Public | Yes | [https://www.bugrakshak.com/platform/leaderboard](https://www.bugrakshak.com/platform/leaderboard) | |
-| BugRap | [https://bugrap.io](https://bugrap.io) | | [@BugRap_Team](https://x.com/BugRap_Team) | Public | Yes | [https://bugrap.io/whiteHats](https://bugrap.io/whiteHats) | [https://bugrap.io/bounties](https://bugrap.io/bounties) |
 | bugsbounty.io | [https://bugsbounty.com](https://bugsbounty.com) | England | [@bugsbounty_com](https://x.com/bugsbounty_com) | Private | | | |
 | Bugv | [https://bugv.io](https://bugv.io) | Nepal | [@bugvsecurity](https://x.com/bugvsecurity) | Public | Yes | | |
 | Butian | [https://butian.net](https://butian.net) | China | | Private + Public | Yes | [https://www.butian.net/Rank/whitehat](https://www.butian.net/Rank/whitehat) | [https://www.butian.net/Reward/plan/2](https://www.butian.net/Reward/plan/2) |
-| Cantina | [https://cantina.xyz](https://cantina.xyz) | USA | [@Cantinaxyz](https://x.com/Cantinaxyz) | Private + Public | Yes | [https://cantina.xyz/leaderboard](https://cantina.xyz/leaderboard) | [https://cantina.xyz/competitions](https://cantina.xyz/competitions) |
 | Capture The Bug | [https://capturethebug.xyz](https://capturethebug.xyz) | New Zealand | [@Capturethebugs](https://x.com/Capturethebugs) | Private | | | |
-| CCB Belgium CVD | [https://ccb.belgium.be/cert/vulnerability-reporting-ccb](https://ccb.belgium.be/cert/vulnerability-reporting-ccb) | Belgium | | Public | No | | |
-| CertiK Bug Bounty | [https://certik.com](https://certik.com) | USA | [@CertiK](https://x.com/CertiK) | Private + Public | Yes | [https://www.certik.com/products/bug-bounty](https://www.certik.com/products/bug-bounty) | |
-| CERT-In RVDCP | [https://www.cert-in.org.in/RVDCP.jsp](https://www.cert-in.org.in/RVDCP.jsp) | India | [@IndianCERT](https://x.com/IndianCERT) | Public | Yes | [https://www.cert-in.org.in/Hallof_Fame.jsp](https://www.cert-in.org.in/Hallof_Fame.jsp) | |
-| Certora Contests | [https://www.certora.com/contests](https://www.certora.com/contests) | Global | [@certora](https://x.com/certora) | Public | Yes | [https://www.certora.com/leaderboard](https://www.certora.com/leaderboard) | [https://www.certora.com/contests](https://www.certora.com/contests) |
-| CERT Polska CVD | [https://cert.pl/en/cvd/](https://cert.pl/en/cvd/) | Poland | [@CERT_Polska_en](https://x.com/CERT_Polska_en) | Public | No | | [https://cert.pl/en/cve/](https://cert.pl/en/cve/) |
-| CISA VDP Platform | [https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform](https://www.cisa.gov/resources-tools/services/vulnerability-disclosure-policy-vdp-platform) | USA | [@CISAgov](https://x.com/CISAgov) | Public | No | | |
 | Cobalt | [https://cobalt.io](https://cobalt.io) | USA | [@cobalt_io](https://x.com/cobalt_io) | Private | Yes | [https://app.us.cobalt.io/pentesters](https://app.us.cobalt.io/pentesters) | |
-| Code4rena | [https://code4rena.com](https://code4rena.com) | | [@code4rena](https://x.com/code4rena) | Public | Yes | [https://code4rena.com/leaderboard](https://code4rena.com/leaderboard) | [https://code4rena.com/contests](https://code4rena.com/contests) |
-| CodeHawks | [https://codehawks.cyfrin.io](https://codehawks.cyfrin.io) | USA | [@CodeHawks](https://x.com/CodeHawks) | Private + Public | Yes | [https://codehawks.cyfrin.io/leaderboard](https://codehawks.cyfrin.io/leaderboard) | [https://codehawks.cyfrin.io/contests](https://codehawks.cyfrin.io/contests) |
 | Com Olho | [https://comolho.com](https://comolho.com) | India | [@com_olho](https://x.com/com_olho) | Private + Public | Yes | [https://cyber.comolho.com/researcher-community/](https://cyber.comolho.com/researcher-community/) | [https://cyber.comolho.com/programs/bug-bounty/](https://cyber.comolho.com/programs/bug-bounty/) |
 | Compass Security | [https://compass-security.com](https://compass-security.com) | Switzerland | [@compasssecurity](https://x.com/compasssecurity) | Private + Public | Yes | | [https://bugbounty.compass-security.com/](https://bugbounty.compass-security.com/) |
 | Crowdswarm | [https://crowdswarm.io](https://crowdswarm.io) | United Arab Emirates | [@Crowdswarm1](https://x.com/Crowdswarm1) | Private + Public | Yes | | |
@@ -71,7 +140,6 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | CyberTalents | [https://cybertalents.com](https://cybertalents.com) | Middle East | [@CyberTalents](https://x.com/CyberTalents) | Public | Yes | [https://cybertalents.com/worldrank](https://cybertalents.com/worldrank) | [https://cybertalents.com/competitions](https://cybertalents.com/competitions) |
 | Cyscope | [https://cyscope.io](https://cyscope.io) | Switzerland & Latam | [@cy_scope](https://x.com/cy_scope) | Private + Public | Yes | | |
 | Detectify | [https://detectify.com](https://detectify.com) | Sweden | [@detectify](https://x.com/detectify) | Crowdsource (ASM) | Yes | | |
-| DIVD | [https://www.divd.nl](https://www.divd.nl) | Netherlands | [@DIVDnl](https://x.com/DIVDnl) | Public | No | | |
 | Dvuln | [https://dvuln.com](https://dvuln.com) | Australia | [@d_vuln](https://x.com/d_vuln) | Private | Yes | | |
 | Federacy | [https://federacy.com](https://federacy.com) | USA | [@_federacy](https://x.com/_federacy) | Private + Public | Yes | | |
 | Find The Gap | [https://findthegap.co.kr/en](https://findthegap.co.kr/en) | South Korea | | Private + Public | No | | |
@@ -79,71 +147,38 @@ Is there a platform or detail missing, or have you spotted something wrong? This
 | Genbounty | [https://genbounty.com/](https://genbounty.com/) | UK | [@Genbounty](https://x.com/genbounty) | Private | Yes | [https://genbounty.com/teams](https://genbounty.com/teams) | |
 | Gerobug | [https://gerobug.gerosecurity.com](https://gerobug.gerosecurity.com) | Indonesia | | Self-hosted | No | | [https://gerobug.gerosecurity.com/programs/](https://gerobug.gerosecurity.com/programs/) |
 | GObugfree | [https://gobugfree.com](https://gobugfree.com) | Switzerland | [@gobugfree](https://x.com/gobugfree) | Private + Public | Yes | | [https://gobugfree.com/programs](https://gobugfree.com/programs) |
-| Gray Swan Arena | [https://app.grayswan.ai/arena](https://app.grayswan.ai/arena) | USA | [@GraySwanAI](https://x.com/GraySwanAI) | Public | Yes | [https://app.grayswan.ai/arena/leaderboard/global](https://app.grayswan.ai/arena/leaderboard/global) | [https://app.grayswan.ai/arena](https://app.grayswan.ai/arena) |
-| HackAPrompt | [https://www.hackaprompt.com](https://www.hackaprompt.com) | USA | | Public | Yes | [https://www.hackaprompt.com/leaderboard](https://www.hackaprompt.com/leaderboard) | |
-| HackenProof | [https://hackenproof.com](https://hackenproof.com) | Estonia | [@HackenProof](https://x.com/HackenProof) | Private + Public | Yes | [https://hackenproof.com/leaderboard](https://hackenproof.com/leaderboard) | [https://hackenproof.com/programs](https://hackenproof.com/programs) |
 | HackerOne | [https://hackerone.com](https://hackerone.com) | USA | [@hacker0x01](https://x.com/hacker0x01) | Private + Public | Yes | [https://hackerone.com/leaderboard](https://hackerone.com/leaderboard) | [https://hackerone.com/directory/programs](https://hackerone.com/directory/programs) |
 | Hackr.fi | [https://www.hackr.fi](https://www.hackr.fi) | Finland | [@hackrfi](https://x.com/hackrfi) | Private + Public | No | | [https://www.hackr.fi/en/programs.html](https://www.hackr.fi/en/programs.html) |
 | Hackrate | [https://hckrt.com](https://hckrt.com) | Hungary | [@hackrate](https://x.com/hackrate) | Private + Public | Yes | | [https://hckrt.com/Catalog](https://hckrt.com/Catalog) |
 | HACKTIFY | [https://hacktify.eu](https://hacktify.eu) | Central and Eastern Europe | [@HACKTIFY_](https://x.com/HACKTIFY_) | Private + Public | Yes | [https://hacktify.eu/en/leaderboard/](https://hacktify.eu/en/leaderboard/) | [https://hacktify.eu/en/public-programs/](https://hacktify.eu/en/public-programs/) |
-| Hashlock | [https://hashlock.com](https://hashlock.com) | Australia | [@HashLockAudit](https://x.com/HashLockAudit) | Private + Public | No | | [https://hashlock.com/bug-bounty](https://hashlock.com/bug-bounty) |
-| Hats | [https://hats.finance](https://hats.finance) | | [@HatsFinance](https://x.com/HatsFinance) | Public | Yes | | |
-| HITCON ZeroDay | [https://zeroday.hitcon.org](https://zeroday.hitcon.org) | Taiwan | [@HacksInTaiwan](https://x.com/HacksInTaiwan) | Private + Public | No | | [https://zeroday.hitcon.org/bug-bounty/list](https://zeroday.hitcon.org/bug-bounty/list) |
 | HuntBug | [https://huntbug.com](https://huntbug.com) | USA | [@officialhuntbug](https://x.com/officialhuntbug) | Private + Public | Yes | [https://huntbug.com/leaderboard](https://huntbug.com/leaderboard) | |
 | HuntersPay | [https://www.hunterspay.com.br](https://www.hunterspay.com.br) | Brazil | | Private + Public | No | | |
-| Huntr | [https://huntr.com](https://huntr.com) | UK | [@huntrdev](https://x.com/huntrdev) | Private + Public | Yes | [https://huntr.com/leaderboard](https://huntr.com/leaderboard) | [https://huntr.com/bounties/hacktivity](https://huntr.com/bounties/hacktivity) |
 | Huoxian | [https://www.huoxian.cn](https://www.huoxian.cn) | China | | Private + Public | Yes | [https://www.huoxian.cn/community](https://www.huoxian.cn/community) | [https://www.huoxian.cn/project](https://www.huoxian.cn/project) |
-| Immunefi | [https://immunefi.com](https://immunefi.com) | | [@immunefi](https://x.com/immunefi) | Public | Yes | [https://immunefi.com/leaderboard/](https://immunefi.com/leaderboard/) | [https://immunefi.com/explore/](https://immunefi.com/explore/) |
 | Inspectiv | [https://inspectiv.com](https://inspectiv.com) | USA | [@inspectiv](https://x.com/inspectiv) | Private + Public | Yes | | |
 | Intigriti | [https://intigriti.com](https://intigriti.com) | Belgium | [@intigriti](https://x.com/intigriti) | Private + Public | Yes | [https://intigriti.com/leaderboard](https://intigriti.com/leaderboard) | [https://intigriti.com/programs](https://intigriti.com/programs) |
-| IssueHunt | [https://issuehunt.io](https://issuehunt.io) | Japan | [@IssueHunt](https://x.com/IssueHunt) | Private + Public | Yes | | [https://issuehunt.io/programs](https://issuehunt.io/programs) |
-| Japan Vulnerability Notes (JVN) | [https://jvn.jp/en/](https://jvn.jp/en/) | Japan | [@jpcert_en](https://x.com/jpcert_en) | Public | No | | [https://jvn.jp/en/nav/](https://jvn.jp/en/nav/) |
-| KISA KNVD | [https://knvd.krcert.or.kr](https://knvd.krcert.or.kr) | South Korea | | Public | No | | |
 | Kolahsefid | [https://www.kolahsefid.org](https://www.kolahsefid.org) | Iran | [@Kolaahsefid](https://x.com/Kolaahsefid) | Private + Public | No | | |
-| NCIIPC RVDP | [https://nciipc.gov.in/RVDP.html](https://nciipc.gov.in/RVDP.html) | India | [@NCIIPC](https://x.com/NCIIPC) | Public | No | | |
-| NCSA Bug Bounty Programme | [https://hub.ncsa.gov.mv/resources/bug-bounty-program](https://hub.ncsa.gov.mv/resources/bug-bounty-program) | Maldives | | Public | Yes | [https://hub.ncsa.gov.mv/bug-bounty/hall-of-fame](https://hub.ncsa.gov.mv/bug-bounty/hall-of-fame) | |
-| NCSC-FI CVD | [https://www.kyberturvallisuuskeskus.fi/en/report](https://www.kyberturvallisuuskeskus.fi/en/report) | Finland | | Public | No | | |
-| NCSC-NL CVD | [https://www.ncsc.nl/contact/kwetsbaarheid-melden](https://www.ncsc.nl/contact/kwetsbaarheid-melden) | Netherlands | | Public | No | | |
-| NKSC Lithuania CVD | [https://www.nksc.lt/pranesti-spraga.html](https://www.nksc.lt/pranesti-spraga.html) | Lithuania | | Public | No | | |
 | Nordic Defender | [https://nordicdefender.com](https://nordicdefender.com) | Sweden | [@nordicdefender](https://x.com/nordicdefender) | Private | | | |
-| ødin | [https://0din.ai](https://0din.ai) | USA | [@0dinai](https://x.com/0dinai) | Public | Yes | [https://0din.ai/leaderboard](https://0din.ai/leaderboard) | [https://0din.ai/scope](https://0din.ai/scope) |
-| Open Bug Bounty | [https://openbugbounty.org](https://openbugbounty.org) | Global | [@openbugbounty](https://x.com/openbugbounty) | Public | Yes | | [https://openbugbounty.org/bugbounty-list/](https://openbugbounty.org/bugbounty-list/) |
-| OpenBounty (Shentu) | [https://openbounty.shentu.org](https://openbounty.shentu.org) | | | Public | Yes | [https://openbounty.shentu.org/leaderboard](https://openbounty.shentu.org/leaderboard) | [https://openbounty.shentu.org/allBounties](https://openbounty.shentu.org/allBounties) |
 | PatchDay | [https://patchday.io](https://patchday.io) | South Korea | [@patchday_io](https://x.com/patchday_io) | Private + Public | Yes | | |
-| Patchstack | [https://patchstack.com](https://patchstack.com) | Estonia | [@paborza](https://x.com/paborza) | Public | Yes | [https://patchstack.com/database/leaderboard](https://patchstack.com/database/leaderboard) | [https://patchstack.com/database/vdp](https://patchstack.com/database/vdp) |
-| Qatar Bug Bounty | [https://bugbounty.qa](https://bugbounty.qa) | Qatar | | Private + Public | No | | |
 | Ravro | [https://ravro.ir](https://ravro.ir) | Iran | [@Ravro_ir](https://x.com/Ravro_ir) | Private + Public | Yes | [https://ravro.ir/reports](https://ravro.ir/reports) | [https://ravro.ir/companies](https://ravro.ir/companies) |
 | RedStorm | [https://redstorm.io](https://redstorm.io) | Indonesia | [@redstorm_io](https://x.com/redstorm_io) | Private + Public | Yes | | [https://redstorm.io/program](https://redstorm.io/program) |
-| Remedy | [https://r.xyz](https://r.xyz) | Global | [@xyz_remedy](https://x.com/xyz_remedy) | Private + Public | No | | [https://hunt.r.xyz](https://hunt.r.xyz) |
 | safehats | [https://safehats.com](https://safehats.com) | India | | Private + Public | | | |
 | Safevuln | [https://safevuln.com](https://safevuln.com) | Vietnam | | Public | Yes | [https://safevuln.com/leaderboard](https://safevuln.com/leaderboard) | [https://safevuln.com/programs](https://safevuln.com/programs) |
 | Secuna | [https://secuna.io](https://secuna.io) | Philippines | [@SecunaSecurity](https://x.com/SecunaSecurity) | Private + Public | Yes | | [https://platform.secuna.io/programs](https://platform.secuna.io/programs) |
 | Secur0 | [https://secur0.com](https://secur0.com) | Europe & Latam | [@Secur00](https://x.com/Secur00) | Private + Public | Yes | [https://app.secur0.com/leaderboards](https://app.secur0.com/leaderboards) | [https://app.secur0.com/programs](https://app.secur0.com/programs) |
-| Secure3 | [https://secure3.io](https://secure3.io) | USA | [@Secure3io](https://x.com/Secure3io) | Private + Public | | | |
-| Sherlock | [https://sherlock.xyz](https://sherlock.xyz) | Global | [@sherlockdefi](https://x.com/sherlockdefi) | Public | Yes | [https://app.sherlock.xyz/audits/leaderboard](https://app.sherlock.xyz/audits/leaderboard) | [https://app.sherlock.xyz/audits/contests](https://app.sherlock.xyz/audits/contests) |
-| Singapore GovTech VDP | [https://www.tech.gov.sg/report-vulnerability/](https://www.tech.gov.sg/report-vulnerability/) | Singapore | [@GovTechSG](https://x.com/GovTechSG) | Public | No | | |
-| SlowMist | [https://slowmist.com](https://slowmist.com) | China | [@SlowMist_Team](https://x.com/SlowMist_Team) | Public | Yes | | [https://slowmist.io/bug-bounty.html](https://slowmist.io/bug-bounty.html) |
-| SSD Secure Disclosure | [https://ssd-disclosure.com](https://ssd-disclosure.com) | Israel | [@SecuriTeam_SSD](https://x.com/SecuriTeam_SSD) | Public | No | | |
 | Standoff 365 Bug Bounty | [https://bugbounty.standoff365.com](https://bugbounty.standoff365.com) | Russia | [@standoff365](https://x.com/standoff365) | Private + Public | Yes | [https://standoff365.com/en-US/ratings/](https://standoff365.com/en-US/ratings/) | [https://bugbounty.standoff365.com/en-US/](https://bugbounty.standoff365.com/en-US/) |
 | Swarmnetics | [https://swarmnetics.com](https://swarmnetics.com) | Singapore | [@swarmnetics](https://x.com/swarmnetics) | Private | Yes | | |
-| Swiss NCSC Bug Bounty | [https://www.ncsc.admin.ch](https://www.ncsc.admin.ch) | Switzerland | | Public | No | | |
 | Synack | [https://synack.com](https://synack.com) | USA | [@synack](https://x.com/synack) | Private | Yes | | |
-| Taiwan Vulnerability Note (TVN) | [https://www.twcert.org.tw/en/np-138-2.html](https://www.twcert.org.tw/en/np-138-2.html) | Taiwan | [@TWCERTCC](https://x.com/TWCERTCC) | Public | No | | [https://www.twcert.org.tw/en/lp-139-2.html](https://www.twcert.org.tw/en/lp-139-2.html) |
 | Teklabspace | [https://teklabspace.com](https://teklabspace.com) | Nigeria | [@teklabspace](https://x.com/teklabspace) | Public | Yes | | |
 | Testbirds | [https://testbirds.com](https://testbirds.com) | Germany | [@Testbirds](https://x.com/Testbirds) | QA + Bug Bounty | No | | |
 | Topcoder | [https://topcoder.com](https://topcoder.com) | USA | [@topcoder](https://x.com/topcoder) | Dev + Bug Bounty | Yes | [https://www.topcoder.com/community/statistics](https://www.topcoder.com/community/statistics) | [https://www.topcoder.com/challenges](https://www.topcoder.com/challenges) |
 | TrustLine | [https://www.trustline.sa](https://www.trustline.sa) | Saudi Arabia | [@trustlineSec](https://x.com/trustlineSec) | Private + Public | | | |
 | TumarOne | [https://tumar.one](https://tumar.one) | Kazakhstan | | Private + Public | Yes | [https://tumar.one/leaderboard](https://tumar.one/leaderboard) | [https://tumar.one/#for-bug-hunters](https://tumar.one/#for-bug-hunters) |
-| UAE National Bug Bounty | [https://bugbounty.ae](https://bugbounty.ae) | United Arab Emirates | | Private | | | |
-| UK NCSC VDP | [https://www.ncsc.gov.uk](https://www.ncsc.gov.uk) | UK | [@NCSC](https://x.com/NCSC) | Public | No | | |
 | UzHunter | [https://uzhunter.com](https://uzhunter.com) | Uzbekistan | | | | | |
 | Vulbox | [https://vulbox.com](https://vulbox.com) | China | | Private + Public | Yes | [https://vulbox.com/top/season](https://vulbox.com/top/season) | [https://vulbox.com/projects/list](https://vulbox.com/projects/list) |
 | Vulnerability Lab | [https://vulnerability-lab.com](https://vulnerability-lab.com) | Germany | | Private + Public | Yes | [https://vulnerability-lab.com/hacktivity.php](https://vulnerability-lab.com/hacktivity.php) | [https://www.vulnerability-lab.com/list-of-bug-bounty-programs.php](https://www.vulnerability-lab.com/list-of-bug-bounty-programs.php) |
 | Vulnscope | [https://vulnscope.com](https://vulnscope.com) | Chile | [@vulnscope](https://x.com/vulnscope) | Private + Public | Yes | [https://vulnscope.com/hacker-ranking](https://vulnscope.com/hacker-ranking) | [https://vulnscope.com/programas](https://vulnscope.com/programas) |
 | WhiteHub | [https://whitehub.net](https://whitehub.net) | Vietnam | [@CyStackSecurity](https://x.com/CyStackSecurity) | Private + Public | Yes | [https://whitehub.net/leaderboard](https://whitehub.net/leaderboard) | [https://whitehub.net/programs](https://whitehub.net/programs) |
-| Wordfence Bug Bounty | [https://www.wordfence.com/threat-intel/bug-bounty-program/](https://www.wordfence.com/threat-intel/bug-bounty-program/) | USA | [@wordfence](https://x.com/wordfence) | Public | No | | |
 | YesWeHack | [https://yeswehack.com](https://yeswehack.com) | France | [@yeswehack](https://x.com/yeswehack) | Private + Public | Yes | [https://yeswehack.com/ranking](https://yeswehack.com/ranking) | [https://yeswehack.com/programs](https://yeswehack.com/programs) |
 | Yogosha | [https://yogosha.com](https://yogosha.com) | France | [@yogoshaofficial](https://x.com/yogoshaofficial) | Private | Yes | [https://yogosha.com/hackers/leaderboard/](https://yogosha.com/hackers/leaderboard/) | |
-| Zero Day Initiative | [https://zerodayinitiative.com](https://zerodayinitiative.com) | USA | [@thezdi](https://x.com/thezdi) | Public | Yes | [https://zerodayinitiative.com/advisories/published/](https://zerodayinitiative.com/advisories/published/) | |
 | Zerocopter | [https://zerocopter.com](https://zerocopter.com) | Netherlands | [@zerocopter](https://x.com/zerocopter) | Private | Yes | | |
 | ZeroDay Test | [https://zerodaytest.com](https://zerodaytest.com) | Bangladesh | [@Zer0day_t3st](https://x.com/Zer0day_t3st) | | | | |


### PR DESCRIPTION
Implements the approved categorization: 6 sections (Gov & public-interest 22 · Web3 16 · AI 4 · Brokered 2 · Ecosystem 3 · General 74), marker + jump-links for the disclose.io renderer (site-side support already live via disclose/website#45, verified backwards-compatible in production), contributing rules (precedence, sub-2 fold, alpha-within-section), badge 109+→121+.

**Conservation guarantee:** generated by script asserting byte-identical set-equality on all 121 data rows — zero cell edits, pure reorganization.